### PR TITLE
OSX and Windows conda-package fixes

### DIFF
--- a/cmake/modules/FindCPLEX.cmake
+++ b/cmake/modules/FindCPLEX.cmake
@@ -7,27 +7,41 @@
 #  CPLEX_INCLUDE_DIRS       - include directory
 #  CPLEX_LIBRARIES          - library files
 
+set(CPLEX_ROOT_DIR "" CACHE PATH "CPLEX root directory.")
+
 if(WIN32)
-  execute_process(COMMAND cmd /C set CPLEX_STUDIO_DIR OUTPUT_VARIABLE CPLEX_STUDIO_DIR_VAR ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-  
-  if(NOT CPLEX_STUDIO_DIR_VAR)
-    MESSAGE(FATAL_ERROR "Unable to find CPLEX: environment variable CPLEX_STUDIO_DIR<VERSION> not set.")
-  endif()
-  
-  STRING(REGEX REPLACE "^CPLEX_STUDIO_DIR" "" CPLEX_STUDIO_DIR_VAR ${CPLEX_STUDIO_DIR_VAR})
-  STRING(REGEX MATCH "^[0-9]+" CPLEX_WIN_VERSION ${CPLEX_STUDIO_DIR_VAR})
-  STRING(REGEX REPLACE "^[0-9]+=" "" CPLEX_STUDIO_DIR_VAR ${CPLEX_STUDIO_DIR_VAR})
-  file(TO_CMAKE_PATH "${CPLEX_STUDIO_DIR_VAR}" CPLEX_ROOT_DIR_GUESS) 
-  
   set(CPLEX_WIN_VERSION ${CPLEX_WIN_VERSION} CACHE STRING "CPLEX version to be used.")
-  set(CPLEX_ROOT_DIR "${CPLEX_ROOT_DIR_GUESS}" CACHE PATH "CPLEX root directory.")
-  
+  if(NOT CPLEX_ROOT_DIR)
+    set(CPLEX_STUDIO_DIR CPLEX_STUDIO_DIR${CPLEX_WIN_VERSION})
+    execute_process(COMMAND cmd /C set ${CPLEX_STUDIO_DIR} OUTPUT_VARIABLE CPLEX_STUDIO_DIR_VAR ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(NOT CPLEX_STUDIO_DIR_VAR)
+      MESSAGE(FATAL_ERROR "Unable to find CPLEX: environment variable CPLEX_STUDIO_DIR<VERSION> not set.")
+    endif()
+
+    STRING(REGEX REPLACE "^CPLEX_STUDIO_DIR" "" CPLEX_STUDIO_DIR_VAR ${CPLEX_STUDIO_DIR_VAR})
+    if(NOT CPLEX_WIN_VERSION)
+      STRING(REGEX MATCH "^[0-9]+" CPLEX_WIN_VERSION ${CPLEX_STUDIO_DIR_VAR})
+    endif()
+
+    STRING(REGEX REPLACE "^[0-9]+=" "" CPLEX_STUDIO_DIR_VAR ${CPLEX_STUDIO_DIR_VAR})
+    file(TO_CMAKE_PATH "${CPLEX_STUDIO_DIR_VAR}" CPLEX_ROOT_DIR)
+
+  elseif(NOT CPLEX_WIN_VERSION)
+    STRING(REGEX MATCH "[0-9]+$" CPLEX_WIN_VERSION ${CPLEX_ROOT_DIR})
+    if(NOT CPLEX_WIN_VERSION)
+      message(FATAL_ERROR "Unable to determine CPLEX version number. Specify CPLEX_WIN_VERSION")
+    endif()
+  endif()
+
   MESSAGE(STATUS "Found CLPEX version ${CPLEX_WIN_VERSION} at '${CPLEX_ROOT_DIR}'")
-  
+
   STRING(REGEX REPLACE "/VC/bin/.*" "" VISUAL_STUDIO_PATH ${CMAKE_C_COMPILER})
   STRING(REGEX MATCH "Studio [0-9]+" CPLEX_WIN_VS_VERSION ${VISUAL_STUDIO_PATH})
   STRING(REGEX REPLACE "Studio " "" CPLEX_WIN_VS_VERSION ${CPLEX_WIN_VS_VERSION})
-  
+
+  set(CPLEX_WIN_VS_VERSION ${CPLEX_WIN_VS_VERSION} CACHE STRING "Visual Studio Version")
+
   if(${CPLEX_WIN_VS_VERSION} STREQUAL "9")
     set(CPLEX_WIN_VS_VERSION 2008)
   elseif(${CPLEX_WIN_VS_VERSION} STREQUAL "10")
@@ -39,31 +53,30 @@ if(WIN32)
   else()
     MESSAGE(FATAL_ERROR "CPLEX: unknown Visual Studio version '${CPLEX_WIN_VS_VERSION}' at '${VISUAL_STUDIO_PATH}'.")
   endif()
-  
-  set(CPLEX_WIN_VS_VERSION ${CPLEX_WIN_VS_VERSION} CACHE STRING "Visual Studio Version")
-  
+
+
   if("${CMAKE_C_COMPILER}" MATCHES "amd64")
     set(CPLEX_WIN_BITNESS x64)
   else()
     set(CPLEX_WIN_BITNESS x86)
   endif()
-  
+
   set(CPLEX_WIN_BITNESS ${CPLEX_WIN_BITNESS} CACHE STRING "On Windows: x86 or x64 (32bit resp. 64bit)")
 
   MESSAGE(STATUS "CPLEX: using Visual Studio ${CPLEX_WIN_VS_VERSION} ${CPLEX_WIN_BITNESS} at '${VISUAL_STUDIO_PATH}'")
 
   if(NOT CPLEX_WIN_LINKAGE)
     set(CPLEX_WIN_LINKAGE mda CACHE STRING "CPLEX linkage variant on Windows. One of these: mda (dll, release), mdd (dll, debug), mta (static, release), mtd (static, debug)")
-  endif(NOT CPLEX_WIN_LINKAGE)
+  endif()
 
   # now, generate platform string
   set(CPLEX_WIN_PLATFORM "${CPLEX_WIN_BITNESS}_windows_vs${CPLEX_WIN_VS_VERSION}/stat_${CPLEX_WIN_LINKAGE}")
 
+  message(STATUS CPLEX_WIN_PLATFORM ${CPLEX_WIN_PLATFORM})
 else()
 
-  set(CPLEX_ROOT_DIR "" CACHE PATH "CPLEX root directory.")
   set(CPLEX_WIN_PLATFORM "")
-  
+
 endif()
 
 
@@ -77,7 +90,7 @@ FIND_PATH(CPLEX_INCLUDE_DIR
   )
 
 FIND_PATH(CPLEX_CONCERT_INCLUDE_DIR
-  ilconcert/iloenv.h 
+  ilconcert/iloenv.h
   HINTS ${CPLEX_ROOT_DIR}/concert/include
         ${CPLEX_ROOT_DIR}/include
   PATHS ENV C_INCLUDE_PATH
@@ -89,21 +102,21 @@ FIND_LIBRARY(CPLEX_LIBRARY
   NAMES cplex${CPLEX_WIN_VERSION} cplex
   HINTS ${CPLEX_ROOT_DIR}/cplex/lib/${CPLEX_WIN_PLATFORM} #windows
         ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_debian4.0_4.1/static_pic #unix
-        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_sles10_4.1/static_pic #unix 
-        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_osx/static_pic #osx 
-        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_darwin/static_pic #osx 
-  PATHS ENV LIBRARY_PATH #unix
-        ENV LD_LIBRARY_PATH #unix
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_sles10_4.1/static_pic #unix
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_osx/static_pic #osx
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_darwin/static_pic #osx
+  PATHS ENV LIBRARY_PATH
+        ENV LD_LIBRARY_PATH
   )
 message(STATUS "CPLEX Library: ${CPLEX_LIBRARY}")
 
 FIND_LIBRARY(CPLEX_ILOCPLEX_LIBRARY
   ilocplex
-  HINTS ${CPLEX_ROOT_DIR}/cplex/lib/${CPLEX_WIN_PLATFORM} #windows 
-        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_debian4.0_4.1/static_pic #unix 
-        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_sles10_4.1/static_pic #unix 
-        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_osx/static_pic #osx 
-        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_darwin/static_pic #osx 
+  HINTS ${CPLEX_ROOT_DIR}/cplex/lib/${CPLEX_WIN_PLATFORM} #windows
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_debian4.0_4.1/static_pic #unix
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_sles10_4.1/static_pic #unix
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_osx/static_pic #osx
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_darwin/static_pic #osx
   PATHS ENV LIBRARY_PATH
         ENV LD_LIBRARY_PATH
   )
@@ -111,11 +124,11 @@ message(STATUS "ILOCPLEX Library: ${CPLEX_ILOCPLEX_LIBRARY}")
 
 FIND_LIBRARY(CPLEX_CONCERT_LIBRARY
   concert
-  HINTS ${CPLEX_ROOT_DIR}/concert/lib/${CPLEX_WIN_PLATFORM} #windows 
-        ${CPLEX_ROOT_DIR}/concert/lib/x86-64_debian4.0_4.1/static_pic #unix 
-        ${CPLEX_ROOT_DIR}/concert/lib/x86-64_sles10_4.1/static_pic #unix 
-        ${CPLEX_ROOT_DIR}/concert/lib/x86-64_osx/static_pic #osx 
-        ${CPLEX_ROOT_DIR}/concert/lib/x86-64_darwin/static_pic #osx 
+  HINTS ${CPLEX_ROOT_DIR}/concert/lib/${CPLEX_WIN_PLATFORM} #windows
+        ${CPLEX_ROOT_DIR}/concert/lib/x86-64_debian4.0_4.1/static_pic #unix
+        ${CPLEX_ROOT_DIR}/concert/lib/x86-64_sles10_4.1/static_pic #unix
+        ${CPLEX_ROOT_DIR}/concert/lib/x86-64_osx/static_pic #osx
+        ${CPLEX_ROOT_DIR}/concert/lib/x86-64_darwin/static_pic #osx
   PATHS ENV LIBRARY_PATH
         ENV LD_LIBRARY_PATH
   )
@@ -128,11 +141,11 @@ if(WIN32)
       )
 else()
     FIND_PATH(CPLEX_BIN_DIR
-      cplex 
-          HINTS ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_sles10_4.1 #unix 
-                ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_debian4.0_4.1 #unix 
-                ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_osx #osx 
-            ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_darwin #osx 
+      cplex
+          HINTS ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_sles10_4.1 #unix
+                ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_debian4.0_4.1 #unix
+                ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_osx #osx
+            ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_darwin #osx
       ENV LIBRARY_PATH
           ENV LD_LIBRARY_PATH
       )
@@ -140,7 +153,7 @@ endif()
 message(STATUS "CPLEX Bin Dir: ${CPLEX_BIN_DIR}")
 
 INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(CPLEX DEFAULT_MSG 
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(CPLEX DEFAULT_MSG
  CPLEX_LIBRARY CPLEX_INCLUDE_DIR CPLEX_ILOCPLEX_LIBRARY CPLEX_CONCERT_LIBRARY CPLEX_CONCERT_INCLUDE_DIR)
 
 IF(CPLEX_FOUND)

--- a/cmake/modules/FindCPLEX.cmake
+++ b/cmake/modules/FindCPLEX.cmake
@@ -1,40 +1,154 @@
-set(CPLEX_ROOT_DIR "" CACHE PATH "CPLEX root directory.")
+# This module finds cplex.
+#
+# User can give CPLEX_ROOT_DIR as a hint stored in the cmake cache.
+#
+# It sets the following variables:
+#  CPLEX_FOUND              - Set to false, or undefined, if cplex isn't found.
+#  CPLEX_INCLUDE_DIRS       - include directory
+#  CPLEX_LIBRARIES          - library files
 
-find_path(CPLEX_INCLUDE_DIR ilcplex/cplex.h HINTS
-    ${CPLEX_ROOT_DIR}/cplex/include
-)
-find_path(CPLEX_CONCERT_INCLUDE_DIR ilconcert/iloenv.h HINTS
-    ${CPLEX_ROOT_DIR}/concert/include
-)
-find_library(CPLEX_LIBRARY NAMES cplex HINTS
-    ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_debian4.0_4.1/static_pic
-    ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_sles10_4.1/static_pic
-    ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_osx/static_pic
-)
-find_library(CPLEX_ILOCPLEX_LIBRARY ilocplex HINTS
-    ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_debian4.0_4.1/static_pic
-    ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_sles10_4.1/static_pic
-    ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_osx/static_pic
-)
-find_library(CPLEX_CONCERT_LIBRARY concert HINTS
-    ${CPLEX_ROOT_DIR}/concert/lib/x86-64_debian4.0_4.1/static_pic
-    ${CPLEX_ROOT_DIR}/concert/lib/x86-64_sles10_4.1/static_pic #unix
-    ${CPLEX_ROOT_DIR}/concert/lib/x86-64_osx/static_pic
-)
-find_path(CPLEX_BIN_DIR cplex HINTS
-    ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_sles10_4.1
-    ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_debian4.0_4.1
-    ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_osx
-)
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CPLEX DEFAULT_MSG CPLEX_LIBRARY CPLEX_INCLUDE_DIR CPLEX_ILOCPLEX_LIBRARY CPLEX_CONCERT_LIBRARY CPLEX_CONCERT_INCLUDE_DIR)
+if(WIN32)
+  execute_process(COMMAND cmd /C set CPLEX_STUDIO_DIR OUTPUT_VARIABLE CPLEX_STUDIO_DIR_VAR ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  
+  if(NOT CPLEX_STUDIO_DIR_VAR)
+    MESSAGE(FATAL_ERROR "Unable to find CPLEX: environment variable CPLEX_STUDIO_DIR<VERSION> not set.")
+  endif()
+  
+  STRING(REGEX REPLACE "^CPLEX_STUDIO_DIR" "" CPLEX_STUDIO_DIR_VAR ${CPLEX_STUDIO_DIR_VAR})
+  STRING(REGEX MATCH "^[0-9]+" CPLEX_WIN_VERSION ${CPLEX_STUDIO_DIR_VAR})
+  STRING(REGEX REPLACE "^[0-9]+=" "" CPLEX_STUDIO_DIR_VAR ${CPLEX_STUDIO_DIR_VAR})
+  file(TO_CMAKE_PATH "${CPLEX_STUDIO_DIR_VAR}" CPLEX_ROOT_DIR_GUESS) 
+  
+  set(CPLEX_WIN_VERSION ${CPLEX_WIN_VERSION} CACHE STRING "CPLEX version to be used.")
+  set(CPLEX_ROOT_DIR "${CPLEX_ROOT_DIR_GUESS}" CACHE PATH "CPLEX root directory.")
+  
+  MESSAGE(STATUS "Found CLPEX version ${CPLEX_WIN_VERSION} at '${CPLEX_ROOT_DIR}'")
+  
+  STRING(REGEX REPLACE "/VC/bin/.*" "" VISUAL_STUDIO_PATH ${CMAKE_C_COMPILER})
+  STRING(REGEX MATCH "Studio [0-9]+" CPLEX_WIN_VS_VERSION ${VISUAL_STUDIO_PATH})
+  STRING(REGEX REPLACE "Studio " "" CPLEX_WIN_VS_VERSION ${CPLEX_WIN_VS_VERSION})
+  
+  if(${CPLEX_WIN_VS_VERSION} STREQUAL "9")
+    set(CPLEX_WIN_VS_VERSION 2008)
+  elseif(${CPLEX_WIN_VS_VERSION} STREQUAL "10")
+    set(CPLEX_WIN_VS_VERSION 2010)
+  elseif(${CPLEX_WIN_VS_VERSION} STREQUAL "11")
+    set(CPLEX_WIN_VS_VERSION 2012)
+  elseif(${CPLEX_WIN_VS_VERSION} STREQUAL "14")
+    set(CPLEX_WIN_VS_VERSION 2015)
+  else()
+    MESSAGE(FATAL_ERROR "CPLEX: unknown Visual Studio version '${CPLEX_WIN_VS_VERSION}' at '${VISUAL_STUDIO_PATH}'.")
+  endif()
+  
+  set(CPLEX_WIN_VS_VERSION ${CPLEX_WIN_VS_VERSION} CACHE STRING "Visual Studio Version")
+  
+  if("${CMAKE_C_COMPILER}" MATCHES "amd64")
+    set(CPLEX_WIN_BITNESS x64)
+  else()
+    set(CPLEX_WIN_BITNESS x86)
+  endif()
+  
+  set(CPLEX_WIN_BITNESS ${CPLEX_WIN_BITNESS} CACHE STRING "On Windows: x86 or x64 (32bit resp. 64bit)")
 
-if(CPLEX_FOUND)
-    set(CPLEX_INCLUDE_DIRS ${CPLEX_INCLUDE_DIR} ${CPLEX_CONCERT_INCLUDE_DIR})
-    set(CPLEX_LIBRARIES ${CPLEX_CONCERT_LIBRARY} ${CPLEX_ILOCPLEX_LIBRARY} ${CPLEX_LIBRARY})
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        set(CPLEX_LIBRARIES "${CPLEX_LIBRARIES};m;pthread")
-    endif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-endif(CPLEX_FOUND)
+  MESSAGE(STATUS "CPLEX: using Visual Studio ${CPLEX_WIN_VS_VERSION} ${CPLEX_WIN_BITNESS} at '${VISUAL_STUDIO_PATH}'")
 
-mark_as_advanced(CPLEX_LIBRARY CPLEX_INCLUDE_DIR CPLEX_ILOCPLEX_LIBRARY CPLEX_CONCERT_INCLUDE_DIR CPLEX_CONCERT_LIBRARY)
+  if(NOT CPLEX_WIN_LINKAGE)
+    set(CPLEX_WIN_LINKAGE mda CACHE STRING "CPLEX linkage variant on Windows. One of these: mda (dll, release), mdd (dll, debug), mta (static, release), mtd (static, debug)")
+  endif(NOT CPLEX_WIN_LINKAGE)
+
+  # now, generate platform string
+  set(CPLEX_WIN_PLATFORM "${CPLEX_WIN_BITNESS}_windows_vs${CPLEX_WIN_VS_VERSION}/stat_${CPLEX_WIN_LINKAGE}")
+
+else()
+
+  set(CPLEX_ROOT_DIR "" CACHE PATH "CPLEX root directory.")
+  set(CPLEX_WIN_PLATFORM "")
+  
+endif()
+
+
+FIND_PATH(CPLEX_INCLUDE_DIR
+  ilcplex/cplex.h
+  HINTS ${CPLEX_ROOT_DIR}/cplex/include
+        ${CPLEX_ROOT_DIR}/include
+  PATHS ENV C_INCLUDE_PATH
+        ENV C_PLUS_INCLUDE_PATH
+        ENV INCLUDE_PATH
+  )
+
+FIND_PATH(CPLEX_CONCERT_INCLUDE_DIR
+  ilconcert/iloenv.h 
+  HINTS ${CPLEX_ROOT_DIR}/concert/include
+        ${CPLEX_ROOT_DIR}/include
+  PATHS ENV C_INCLUDE_PATH
+        ENV C_PLUS_INCLUDE_PATH
+        ENV INCLUDE_PATH
+  )
+
+FIND_LIBRARY(CPLEX_LIBRARY
+  NAMES cplex${CPLEX_WIN_VERSION} cplex
+  HINTS ${CPLEX_ROOT_DIR}/cplex/lib/${CPLEX_WIN_PLATFORM} #windows
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_debian4.0_4.1/static_pic #unix
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_sles10_4.1/static_pic #unix 
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_osx/static_pic #osx 
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_darwin/static_pic #osx 
+  PATHS ENV LIBRARY_PATH #unix
+        ENV LD_LIBRARY_PATH #unix
+  )
+message(STATUS "CPLEX Library: ${CPLEX_LIBRARY}")
+
+FIND_LIBRARY(CPLEX_ILOCPLEX_LIBRARY
+  ilocplex
+  HINTS ${CPLEX_ROOT_DIR}/cplex/lib/${CPLEX_WIN_PLATFORM} #windows 
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_debian4.0_4.1/static_pic #unix 
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_sles10_4.1/static_pic #unix 
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_osx/static_pic #osx 
+        ${CPLEX_ROOT_DIR}/cplex/lib/x86-64_darwin/static_pic #osx 
+  PATHS ENV LIBRARY_PATH
+        ENV LD_LIBRARY_PATH
+  )
+message(STATUS "ILOCPLEX Library: ${CPLEX_ILOCPLEX_LIBRARY}")
+
+FIND_LIBRARY(CPLEX_CONCERT_LIBRARY
+  concert
+  HINTS ${CPLEX_ROOT_DIR}/concert/lib/${CPLEX_WIN_PLATFORM} #windows 
+        ${CPLEX_ROOT_DIR}/concert/lib/x86-64_debian4.0_4.1/static_pic #unix 
+        ${CPLEX_ROOT_DIR}/concert/lib/x86-64_sles10_4.1/static_pic #unix 
+        ${CPLEX_ROOT_DIR}/concert/lib/x86-64_osx/static_pic #osx 
+        ${CPLEX_ROOT_DIR}/concert/lib/x86-64_darwin/static_pic #osx 
+  PATHS ENV LIBRARY_PATH
+        ENV LD_LIBRARY_PATH
+  )
+message(STATUS "CONCERT Library: ${CPLEX_CONCERT_LIBRARY}")
+
+if(WIN32)
+    FIND_PATH(CPLEX_BIN_DIR
+      cplex${CPLEX_WIN_VERSION}.dll
+          HINTS ${CPLEX_ROOT_DIR}/cplex/bin/${CPLEX_WIN_PLATFORM} #windows
+      )
+else()
+    FIND_PATH(CPLEX_BIN_DIR
+      cplex 
+          HINTS ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_sles10_4.1 #unix 
+                ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_debian4.0_4.1 #unix 
+                ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_osx #osx 
+            ${CPLEX_ROOT_DIR}/cplex/bin/x86-64_darwin #osx 
+      ENV LIBRARY_PATH
+          ENV LD_LIBRARY_PATH
+      )
+endif()
+message(STATUS "CPLEX Bin Dir: ${CPLEX_BIN_DIR}")
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(CPLEX DEFAULT_MSG 
+ CPLEX_LIBRARY CPLEX_INCLUDE_DIR CPLEX_ILOCPLEX_LIBRARY CPLEX_CONCERT_LIBRARY CPLEX_CONCERT_INCLUDE_DIR)
+
+IF(CPLEX_FOUND)
+  SET(CPLEX_INCLUDE_DIRS ${CPLEX_INCLUDE_DIR} ${CPLEX_CONCERT_INCLUDE_DIR})
+  SET(CPLEX_LIBRARIES ${CPLEX_CONCERT_LIBRARY} ${CPLEX_ILOCPLEX_LIBRARY} ${CPLEX_LIBRARY} )
+  IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    SET(CPLEX_LIBRARIES "${CPLEX_LIBRARIES};m;pthread")
+  ENDIF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+ENDIF(CPLEX_FOUND)
+
+MARK_AS_ADVANCED(CPLEX_LIBRARY CPLEX_INCLUDE_DIR CPLEX_ILOCPLEX_LIBRARY CPLEX_CONCERT_INCLUDE_DIR CPLEX_CONCERT_LIBRARY)

--- a/conda-recipe/README
+++ b/conda-recipe/README
@@ -11,10 +11,10 @@ Configure your environment to select the variant to build.
 Examples:
 
 # Build nifty
-conda build conda-recipe
+WITH_CPLEX=0 WITH_GUROBI=0 conda build conda-recipe
 
 # Build nifty-with-cplex
-WITH_CPLEX=1 CPLEX_ROOT_DIR=/path/to/ibm/ILOG/CPLEX_Studio1251 conda build conda-recipe
+WITH_CPLEX=1 WITH_GUROBI=0 CPLEX_ROOT_DIR=/path/to/ibm/ILOG/CPLEX_Studio1251 conda build conda-recipe
 
 # Build nifty-with-gurobi
-WITH_GUROBI=1 GUROBI_ROOT_DIR=/path/to/gurobi650/linux64 conda build conda-recipe
+WITH_CPLEX=0 WITH_GUROBI=1 GUROBI_ROOT_DIR=/path/to/gurobi650/linux64 conda build conda-recipe

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -38,7 +38,7 @@ IF "%WITH_GUROBI%" == "1" (
     rem set /p GUROBI_LIB=<gurobilib.tmp
 ) 
 
-IF "%WITH_CPLEX" == "1" (
+IF "%WITH_CPLEX%" == "1" (
     REM CPLEX is found automatically if installed. 
     REM No idea what happens with two CPLEXinstallations, but for now we don't care.
     SET OPTIMIZER_ARGS="-DWITH_CPLEX=ON"

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,0 +1,62 @@
+mkdir build
+cd build
+
+REM ----------------------------------------------------------------------
+IF NOT DEFINED WITH_CPLEX (SET WITH_CPLEX=0)
+IF NOT DEFINED WITH_GUROBI (SET WITH_GUROBI=0)
+IF %WITH_CPLEX% == "" (SET WITH_CPLEX=0)
+IF %WITH_GUROBI% == "" (SET WITH_GUROBI=0)
+
+SET OPTIMIZER_ARGS=
+IF "%WITH_GUROBI%" == "1" (
+    IF NOT DEFINED GUROBI_ROOT_DIR (
+        ECHO "GUROBI_ROOT_DIR must be set for building!"
+        exit 1
+    )
+    IF "%GUROBI_ROOT_DIR%" == "" (
+        ECHO "GUROBI_ROOT_DIR cannot be empty for building!"
+        exit 1
+    ) ELSE (
+        ECHO "Using GUROBI_ROOT_DIR=%GUROBI_ROOT_DIR%"
+    )
+    REM if we build with Gurobi, we need to configure the paths.
+    REM MHT chooses gurobi first if that is configured.
+    REM The GUROBI_ROOT_DIR should point to gurobiXYZ\win64
+    dir "%GUROBI_ROOT_DIR%\lib\gurobi*.lib" /s/b | findstr gurobi[0-9][0-9].lib > gurobilib.tmp
+    set /p GUROBI_LIB=<gurobilib.tmp
+    ECHO found gurobi lib %GUROBI_LIB%
+    SET OPTIMIZER_ARGS=-DWITH_GUROBI=ON -DGUROBI_ROOT_DIR=%GUROBI_ROOT_DIR% ^
+      -DGUROBI_LIBRARY=%GUROBI_LIB% -DGUROBI_INCLUDE_DIR=%GUROBI_ROOT_DIR%\include ^
+      -DGUROBI_CXX_LIBRARY=%GUROBI_ROOT_DIR%\lib\gurobi_c++md2015.lib
+) 
+
+IF "%WITH_CPLEX" == "1" (
+    REM CPLEX is found automatically if installed. 
+    REM No idea what happens with two CPLEXinstallations, but for now we don't care.
+    SET OPTIMIZER_ARGS="-DWITH_CPLEX=ON"
+)
+
+REM ----------------------------------------------------------------------
+
+set CONFIGURATION=Release
+
+cmake .. -G "%CMAKE_GENERATOR%" -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%"  ^
+    -DBOOST_ROOT="%LIBRARY%" ^
+    -DCMAKE_CXX_FLAGS="-DBOOST_ALL_NO_LIB /EHsc" ^
+    ^
+    %OPTIMIZER_ARGS% ^
+    ^
+    -DPYTHON_EXECUTABLE=%PYTHON% ^
+    -DBUILD_NIFTY_PYTHON=yes ^
+    -DBUILD_CPP_TEST=no ^
+    -DBUILD_CPP_EXAMPLES=no ^
+    -DWITH_GLPK=no ^
+    -DWITH_HDF5=yes ^
+    -DWITH_LP_MP=no ^
+    -DWITH_QPBO=no
+
+cmake --build . --target ALL_BUILD --config %CONFIGURATION%
+if errorlevel 1 exit 1
+cmake --build . --target INSTALL --config %CONFIGURATION%
+if errorlevel 1 exit 1

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -31,8 +31,8 @@ IF "%WITH_GUROBI%" == "1" (
     REM The GUROBI_ROOT_DIR should point to gurobiXYZ\win64
     ECHO "found gurobi lib %GUROBI_LIB_WIN%"
     :: ensure single double quotes with :"=
-    SET OPTIMIZER_ARGS=-DWITH_GUROBI=ON -DGUROBI_ROOT_DIR="%GUROBI_ROOT_DIR:"=%"" ^
-      -DGUROBI_LIBRARY=%GUROBI_LIB_WIN% -DGUROBI_INCLUDE_DIR="%GUROBI_ROOT_DIR:"=%\include" ^
+    SET OPTIMIZER_ARGS=-DWITH_GUROBI=ON -DGUROBI_ROOT_DIR="%GUROBI_ROOT_DIR:"=%" ^
+      -DGUROBI_LIBRARY="%GUROBI_LIB_WIN:"=%" -DGUROBI_INCLUDE_DIR="%GUROBI_ROOT_DIR:"=%\include" ^
       -DGUROBI_CPP_LIBRARY="%GUROBI_ROOT_DIR:"=%\lib\gurobi_c++md2015.lib"
     rem set GUROBI_LIB=%%i
     rem dir "%GUROBI_ROOT_DIR%\lib\gurobi*.lib" /s/b|findstr gurobi[0-9][0-9].lib>gurobilib.tmp

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -41,7 +41,7 @@ IF "%WITH_GUROBI%" == "1" (
 
 IF "%WITH_CPLEX%" == "1" (
     :: ensure single double quotes with :"=
-    SET OPTIMIZER_ARGS=-DWITH_CPLEX=ON -DCPLEX_ROOT_DIR="%CPLEX_ROOT_DIR:"=%"
+    SET OPTIMIZER_ARGS=-DWITH_CPLEX=ON -DCPLEX_ROOT_DIR=%CPLEX_ROOT_DIR% -DCPLEX_WIN_VERSION=%CPLEX_WIN_VERSION%
 )
 
 REM ----------------------------------------------------------------------

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -39,9 +39,7 @@ IF "%WITH_GUROBI%" == "1" (
 ) 
 
 IF "%WITH_CPLEX%" == "1" (
-    REM CPLEX is found automatically if installed. 
-    REM No idea what happens with two CPLEXinstallations, but for now we don't care.
-    SET OPTIMIZER_ARGS="-DWITH_CPLEX=ON"
+    SET OPTIMIZER_ARGS="-DWITH_CPLEX=ON -DCPLEX_ROOT_DIR=%CPLEX_ROOT_DIR%"
 )
 
 REM ----------------------------------------------------------------------

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -19,15 +19,23 @@ IF "%WITH_GUROBI%" == "1" (
     ) ELSE (
         ECHO "Using GUROBI_ROOT_DIR=%GUROBI_ROOT_DIR%"
     )
+    IF NOT DEFINED GUROBI_ROOT_DIR (
+        ECHO "GUROBI_LIB_WIN must be set for building!"
+        exit 1
+    )
+    IF "%GUROBI_LIB_WIN%" == "" (
+        ECHO "GUROBI_LIB_WIN cannot be empty for building!"
+        exit 1
+    )
     REM if we build with Gurobi, we need to configure the paths.
-    REM MHT chooses gurobi first if that is configured.
     REM The GUROBI_ROOT_DIR should point to gurobiXYZ\win64
-    dir "%GUROBI_ROOT_DIR%\lib\gurobi*.lib" /s/b | findstr gurobi[0-9][0-9].lib > gurobilib.tmp
-    set /p GUROBI_LIB=<gurobilib.tmp
-    ECHO found gurobi lib %GUROBI_LIB%
+    ECHO "found gurobi lib %GUROBI_LIB_WIN%"
     SET OPTIMIZER_ARGS=-DWITH_GUROBI=ON -DGUROBI_ROOT_DIR=%GUROBI_ROOT_DIR% ^
-      -DGUROBI_LIBRARY=%GUROBI_LIB% -DGUROBI_INCLUDE_DIR=%GUROBI_ROOT_DIR%\include ^
-      -DGUROBI_CXX_LIBRARY=%GUROBI_ROOT_DIR%\lib\gurobi_c++md2015.lib
+      -DGUROBI_LIBRARY=%GUROBI_LIB_WIN% -DGUROBI_INCLUDE_DIR=%GUROBI_ROOT_DIR%\include ^
+      -DGUROBI_CPP_LIBRARY=%GUROBI_ROOT_DIR%\lib\gurobi_c++md2015.lib
+    rem set GUROBI_LIB=%%i
+    rem dir "%GUROBI_ROOT_DIR%\lib\gurobi*.lib" /s/b|findstr gurobi[0-9][0-9].lib>gurobilib.tmp
+    rem set /p GUROBI_LIB=<gurobilib.tmp
 ) 
 
 IF "%WITH_CPLEX" == "1" (
@@ -60,3 +68,16 @@ cmake --build . --target ALL_BUILD --config %CONFIGURATION%
 if errorlevel 1 exit 1
 cmake --build . --target INSTALL --config %CONFIGURATION%
 if errorlevel 1 exit 1
+
+
+IF "%WITH_GUROBI%" == "1" (
+    REM Rename the nifty package to 'nifty_with_gurobi'
+    cd "%SP_DIR%"
+    rename nifty nifty_with_gurobi
+)
+
+IF "%WITH_CPLEX%" == "1" (
+    REM Rename the nifty package to 'nifty_with_cplex'
+    cd "%SP_DIR%"
+    rename nifty nifty_with_cplex
+)

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -30,16 +30,18 @@ IF "%WITH_GUROBI%" == "1" (
     REM if we build with Gurobi, we need to configure the paths.
     REM The GUROBI_ROOT_DIR should point to gurobiXYZ\win64
     ECHO "found gurobi lib %GUROBI_LIB_WIN%"
-    SET OPTIMIZER_ARGS=-DWITH_GUROBI=ON -DGUROBI_ROOT_DIR=%GUROBI_ROOT_DIR% ^
-      -DGUROBI_LIBRARY=%GUROBI_LIB_WIN% -DGUROBI_INCLUDE_DIR=%GUROBI_ROOT_DIR%\include ^
-      -DGUROBI_CPP_LIBRARY=%GUROBI_ROOT_DIR%\lib\gurobi_c++md2015.lib
+    :: ensure single double quotes with :"=
+    SET OPTIMIZER_ARGS=-DWITH_GUROBI=ON -DGUROBI_ROOT_DIR="%GUROBI_ROOT_DIR:"=%"" ^
+      -DGUROBI_LIBRARY=%GUROBI_LIB_WIN% -DGUROBI_INCLUDE_DIR="%GUROBI_ROOT_DIR:"=%\include" ^
+      -DGUROBI_CPP_LIBRARY="%GUROBI_ROOT_DIR:"=%\lib\gurobi_c++md2015.lib"
     rem set GUROBI_LIB=%%i
     rem dir "%GUROBI_ROOT_DIR%\lib\gurobi*.lib" /s/b|findstr gurobi[0-9][0-9].lib>gurobilib.tmp
     rem set /p GUROBI_LIB=<gurobilib.tmp
-) 
+)
 
 IF "%WITH_CPLEX%" == "1" (
-    SET OPTIMIZER_ARGS="-DWITH_CPLEX=ON -DCPLEX_ROOT_DIR=%CPLEX_ROOT_DIR%"
+    :: ensure single double quotes with :"=
+    SET OPTIMIZER_ARGS=-DWITH_CPLEX=ON -DCPLEX_ROOT_DIR="%CPLEX_ROOT_DIR:"=%"
 )
 
 REM ----------------------------------------------------------------------

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -183,7 +183,7 @@ NIFTY_MODULE_SO=${PREFIX}/lib/python${PY_VER}/site-packages/nifty/_nifty.so
 ##
 ## Rename the python module entirely, and change cplex lib install names.
 ##
-if [[ "$WITH_CPLEX" != "" ]]; then
+if [[ "$WITH_CPLEX" == "1" ]]; then
     (
         if [ `uname` == "Darwin" ]; then
             # Set install names according using @rpath
@@ -201,7 +201,7 @@ fi
 ##
 ## Rename the python module entirely, and change cplex lib install names.
 ##
-if [[ "$WITH_GUROBI" != "" ]]; then
+if [[ "$WITH_GUROBI" == "1" ]]; then
     (
         if [ `uname` == "Darwin" ]; then
             # Set install name according using @rpath

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -6,9 +6,6 @@
 ## - PREFIX, PYTHON, CPU_COUNT, etc. (as defined by conda-build)
 
 # Convert '0' to empty (all code below treats non-empty as True)
-if [[ "$WITH_CPLEX" == "0" ]]; then
-    WITH_CPLEX=""
-fi
 
 # Platform-specific dylib extension
 if [ $(uname) == "Darwin" ]; then
@@ -22,7 +19,7 @@ else
 fi
 
 # Pre-define special flags, paths, etc. if we're building with CPLEX support.
-if [[ "$WITH_CPLEX" == "" ]]; then
+if [[ "$WITH_CPLEX" == "0" ]]; then
     CPLEX_ARGS=""
     LINKER_FLAGS=""
 else
@@ -97,7 +94,7 @@ else
     CPLEX_ARGS="${CPLEX_ARGS} -DCPLEX_BIN_DIR=${CPLEX_CONCERT_LIBRARY}"
 fi
 
-if [[ "$WITH_GUROBI" == "" ]]; then
+if [[ "$WITH_GUROBI" == "0" ]]; then
     GUROBI_ARGS=""
     LINKER_FLAGS=""
 else

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -178,7 +178,7 @@ make -j${CPU_COUNT}
 cp -r ${SRC_DIR}/build/python/nifty ${PREFIX}/lib/python${PY_VER}/site-packages/
 
 
-NIFTY_MODULE_SO=${PREFIX}/lib/python${PY_VER}/site-packages/nifty/_nifty.so
+NIFTY_MODULE_SO=`ls ${PREFIX}/lib/python${PY_VER}/site-packages/nifty/_nifty.*`
 
 ##
 ## Rename the python module entirely, and change cplex lib install names.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -40,6 +40,7 @@ build:
      - CPLEX_ROOT_DIR
      - WITH_GUROBI
      - GUROBI_ROOT_DIR
+     - GUROBI_LIB_WIN # [win]
 
 requirements:
   build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -47,7 +47,6 @@ requirements:
     - boost 1.63.0
     - python {{PY_VER}}*
     - hdf5 1.10.1 # Need this version to be compatible with current vigra package
-    - h5py 2.7.1
     - fastfilters
     {% if WITH_CPLEX is defined and WITH_CPLEX == "1" %}
     - cplex-shared # [not win]
@@ -62,7 +61,6 @@ requirements:
     - boost 1.63.0
     - python {{PY_VER}}*
     - hdf5  1.10.1 # Need this version to be compatible with current vigra package
-    - h5py 2.7.1
     - numpy # Numpy version is not constrained, thanks to pybind11 magic
     - fastfilters
     - scikit-image

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -46,7 +46,8 @@ requirements:
   build:
     - boost 1.63.0
     - python {{PY_VER}}*
-    - hdf5 1.8.17 # Need this version to be compatible with current vigra package
+    - hdf5 1.10.1 # Need this version to be compatible with current vigra package
+    - h5py 2.7.1
     - fastfilters
     {% if WITH_CPLEX is defined and WITH_CPLEX == "1" %}
     - cplex-shared # [not win]
@@ -60,7 +61,8 @@ requirements:
   run:
     - boost 1.63.0
     - python {{PY_VER}}*
-    - hdf5 1.8.17 # Need this version to be compatible with current vigra package
+    - hdf5  1.10.1 # Need this version to be compatible with current vigra package
+    - h5py 2.7.1
     - numpy # Numpy version is not constrained, thanks to pybind11 magic
     - fastfilters
     - scikit-image

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,15 +1,15 @@
 {% if not WITH_CPLEX is defined %}
-  {% set WITH_CPLEX = False %}
+  {% set WITH_CPLEX = 0 %}
 {% endif %}
 
 {% if not WITH_GUROBI is defined %}
-  {% set WITH_GUROBI = False %}
+  {% set WITH_GUROBI = 0 %}
 {% endif %}
 
 package:
-  {% if WITH_CPLEX %}
+  {% if WITH_CPLEX == "1" %}
     name: nifty-with-cplex
-  {% elif WITH_GUROBI %}
+  {% elif WITH_GUROBI == "1" %}
     name: nifty-with-gurobi
   {% else %}
     name: nifty
@@ -47,13 +47,13 @@ requirements:
     - python {{PY_VER}}*
     - hdf5 1.8.17 # Need this version to be compatible with current vigra package
     - fastfilters
-    {% if WITH_CPLEX is defined and WITH_CPLEX %}
-    - cplex-shared # Need to make sure that cplex dylibs exist
+    {% if WITH_CPLEX is defined and WITH_CPLEX == "1" %}
+    - cplex-shared # [not win]
     {% endif %}
 
     # Must provide symlinks so that the conda doesn't complain when it 'fixes' linking in _nifty.so
-    {% if WITH_GUROBI is defined and WITH_GUROBI %}
-    - gurobi-symlink
+    {% if WITH_GUROBI is defined and WITH_GUROBI == "1" %}
+    - gurobi-symlink # [not win]
     {% endif %}
 
   run:
@@ -67,11 +67,11 @@ requirements:
     - futures # [py2k]
 
     {% if WITH_CPLEX is defined and WITH_CPLEX %}
-    - cplex-shared # Need to make sure that cplex dylibs exist
+    - cplex-shared # [not win]
     {% endif %}
 
     {% if WITH_GUROBI is defined and WITH_GUROBI %}
-    - gurobi-symlink
+    - gurobi-symlink # [not win]
     {% endif %}
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -66,19 +66,19 @@ requirements:
     - scipy
     - futures # [py2k]
 
-    {% if WITH_CPLEX is defined and WITH_CPLEX %}
+    {% if WITH_CPLEX is defined and WITH_CPLEX == "1" %}
     - cplex-shared # [not win]
     {% endif %}
 
-    {% if WITH_GUROBI is defined and WITH_GUROBI %}
+    {% if WITH_GUROBI is defined and WITH_GUROBI == "1" %}
     - gurobi-symlink # [not win]
     {% endif %}
 
 test:
-  {% if WITH_CPLEX %}
+  {% if WITH_CPLEX is defined and WITH_CPLEX == "1" %}
     imports:
       - nifty_with_cplex
-  {% elif WITH_GUROBI %}
+  {% elif WITH_GUROBI is defined and WITH_GUROBI == "1" %}
     imports:
       - nifty_with_gurobi
   {% else %}

--- a/include/nifty/array/arithmetic_array.hxx
+++ b/include/nifty/array/arithmetic_array.hxx
@@ -107,7 +107,7 @@ namespace array{
     // since it is an aggregate we need
     // to impl. this 
     // => we are giving up the aggregate status
-    template<class T, size_t DIM>
+    template<class T, std::size_t DIM>
     class StaticArrayBase : public std::array<T,DIM>{
     public:
         typedef  std::array<T,DIM> BaseType;
@@ -139,7 +139,7 @@ namespace array{
     };
 
 
-    template<class T,size_t SIZE>
+    template<class T,std::size_t SIZE>
     using StaticArray = ArrayExtender< StaticArrayBase<T,SIZE> >; 
 
     // template<class T, class ALLOCATOR = std::allocator<T> >

--- a/include/nifty/array/static_array.hxx
+++ b/include/nifty/array/static_array.hxx
@@ -6,7 +6,7 @@
 namespace nifty{
 namespace array{
 
-    template<class T,size_t SIZE>
+    template<class T,std::size_t SIZE>
     using StaticArray = ArrayExtender< StaticArrayBase<T,SIZE> >; 
 
 

--- a/include/nifty/cgp/bounds.hxx
+++ b/include/nifty/cgp/bounds.hxx
@@ -11,14 +11,14 @@
 namespace nifty{
 namespace cgp{
 
-    template<size_t DIM>
+    template<std::size_t DIM>
     class Bounds;
 
-    template<size_t DIM, size_t CELL_TYPE>
+    template<std::size_t DIM, std::size_t CELL_TYPE>
     class CellBoundedByVector;
 
 
-    template<size_t DIM, size_t CELL_TYPE>
+    template<std::size_t DIM, std::size_t CELL_TYPE>
     class CellBounds;
 
     template<>
@@ -70,7 +70,7 @@ namespace cgp{
         uint32_t data_[2];
     };
 
-    template<size_t DIM, size_t CELL_TYPE>
+    template<std::size_t DIM, std::size_t CELL_TYPE>
     class CellBoundedBy;
 
 
@@ -94,7 +94,7 @@ namespace cgp{
                 return 2;
             }
         }
-        const uint32_t & operator[](const size_t i)const{
+        const uint32_t & operator[](const std::size_t i)const{
             return data_[i];
         }
     private:
@@ -112,7 +112,7 @@ namespace cgp{
         uint32_t size()const{
             return data_.size();
         }
-        const uint32_t & operator[](const size_t i)const{
+        const uint32_t & operator[](const std::size_t i)const{
             return data_[i];
         }
     private:
@@ -120,7 +120,7 @@ namespace cgp{
     };
 
 
-    template<size_t DIM, size_t CELL_TYPE>
+    template<std::size_t DIM, std::size_t CELL_TYPE>
     class CellBoundsVector : public std::vector<CellBounds<DIM, CELL_TYPE>>{
     public:
 
@@ -137,7 +137,7 @@ namespace cgp{
         NumberOfCellsType numberOfCells_;
     };
 
-    template<size_t DIM, size_t CELL_TYPE>
+    template<std::size_t DIM, std::size_t CELL_TYPE>
     class CellBoundedByVector;
 
 
@@ -193,7 +193,7 @@ namespace cgp{
 
 
 
-    template<size_t DIM>
+    template<std::size_t DIM>
     class Bounds;
 
     template<>
@@ -207,7 +207,7 @@ namespace cgp{
 
         Bounds(const TopologicalGridType & tGrid);
 
-        template<size_t CELL_TYPE>
+        template<std::size_t CELL_TYPE>
         const CellBoundsVector<2, CELL_TYPE> &
         bounds()const{
             return std::get<CELL_TYPE>(bounds_);

--- a/include/nifty/cgp/features/geometric_features.hxx
+++ b/include/nifty/cgp/features/geometric_features.hxx
@@ -30,7 +30,7 @@ namespace cgp{
 
         }
 
-        size_t numberOfFeatures()const{
+        std::size_t numberOfFeatures()const{
             return sigmas_.size() * AccType::NFeatures::value;   
         }
         
@@ -144,13 +144,13 @@ namespace cgp{
         typedef nifty::features::DefaultAccumulatedStatistics<float> AccType;
     public:
         Cell1LineSegmentDist2D(
-            const std::vector<size_t> & dists  = std::vector<size_t>({size_t(3),size_t(5),size_t(7)})
+            const std::vector<std::size_t> & dists  = std::vector<std::size_t>({std::size_t(3),std::size_t(5),std::size_t(7)})
         )
         :   dists_(dists)
         {
         }
 
-        size_t numberOfFeatures()const{
+        std::size_t numberOfFeatures()const{
             return  dists_.size()*AccType::NFeatures::value;
         }
 
@@ -245,7 +245,7 @@ namespace cgp{
             }
         }
     private:
-        std::vector<size_t> dists_;
+        std::vector<std::size_t> dists_;
     };
 
 
@@ -256,7 +256,7 @@ namespace cgp{
         Cell1BasicGeometricFeatures2D(){
         }
 
-        size_t numberOfFeatures()const{
+        std::size_t numberOfFeatures()const{
             return 4 * 4 +  2*AccType::NFeatures::value + 4;   
         }
 
@@ -442,7 +442,7 @@ namespace cgp{
         
         }
     private:
-        std::vector<size_t> dists_;
+        std::vector<std::size_t> dists_;
     };
 
 
@@ -452,13 +452,13 @@ namespace cgp{
         typedef nifty::features::DefaultAccumulatedStatistics<float> AccType;
     public:
         GeometricAccumulator(
-            const std::vector<size_t> & dists  = std::vector<size_t>({size_t(3),size_t(5),size_t(7)})
+            const std::vector<std::size_t> & dists  = std::vector<std::size_t>({std::size_t(3),std::size_t(5),std::size_t(7)})
         )
         :   dists_(dists)
         {
         }
 
-        size_t numberOfFeatures()const{
+        std::size_t numberOfFeatures()const{
             return  dists_.size()*AccType::NFeatures::value;
         }
             
@@ -484,7 +484,7 @@ namespace cgp{
         
         }
     private:
-        std::vector<size_t> dists_;
+        std::vector<std::size_t> dists_;
     };
     */
 

--- a/include/nifty/cgp/features/topological_features.hxx
+++ b/include/nifty/cgp/features/topological_features.hxx
@@ -20,7 +20,7 @@ namespace cgp{
         Cell1BasicTopologicalFeatures(){
         }
 
-        size_t numberOfFeatures()const{
+        std::size_t numberOfFeatures()const{
             return 6;
         }
             
@@ -95,7 +95,7 @@ namespace cgp{
         
         }
     private:
-        std::vector<size_t> dists_;
+        std::vector<std::size_t> dists_;
     };
 
 

--- a/include/nifty/cgp/filled_topological_grid.hxx
+++ b/include/nifty/cgp/filled_topological_grid.hxx
@@ -14,7 +14,7 @@ namespace cgp{
 
 
 
-    template<size_t DIM>
+    template<std::size_t DIM>
     class FilledTopologicalGrid;
 
 

--- a/include/nifty/cgp/geometry.hxx
+++ b/include/nifty/cgp/geometry.hxx
@@ -13,23 +13,23 @@ namespace nifty{
 namespace cgp{
 
 
-    template<size_t DIM>
+    template<std::size_t DIM>
     class Geometry;
 
     
-    template<size_t DIM, size_t CELL_TYPE>
+    template<std::size_t DIM, std::size_t CELL_TYPE>
     class CellGeometry;
 
     // zero cell should be the same for all dimensions,
     // a single dot
-    template<size_t DIM>
+    template<std::size_t DIM>
     class CellGeometry<DIM, 0> : public std::array<
         array::StaticArray<uint32_t, 2>, 
         1 
     >
     {
     public:
-        typedef std::integral_constant<size_t, DIM> DimensionType;
+        typedef std::integral_constant<std::size_t, DIM> DimensionType;
         typedef nifty::array::StaticArray<uint32_t, 2> CoordinateType;
         typedef nifty::array::StaticArray<float, DIM> FloatCoordinateType;
         typedef std::array<CoordinateType, 1> BaseType;
@@ -49,8 +49,8 @@ namespace cgp{
     class CellGeometry<2, 1> : public std::vector< array::StaticArray<uint32_t, 2> > {
     public:
         friend class Geometry<2>;
-        const static size_t DIM = 2;
-        typedef std::integral_constant<size_t, DIM> DimensionType;
+        const static std::size_t DIM = 2;
+        typedef std::integral_constant<std::size_t, DIM> DimensionType;
         typedef nifty::array::StaticArray<uint32_t, DIM> CoordinateType;
         typedef nifty::array::StaticArray<float, DIM> FloatCoordinateType;
         typedef std::vector<CoordinateType> BaseType;
@@ -79,10 +79,10 @@ namespace cgp{
 
 
     // default cell
-    template<size_t DIM, size_t CELL_TYPE>
+    template<std::size_t DIM, std::size_t CELL_TYPE>
     class CellGeometry : public std::vector< array::StaticArray<uint32_t, DIM> > {
     public:
-        typedef std::integral_constant<size_t, DIM> DimensionType;
+        typedef std::integral_constant<std::size_t, DIM> DimensionType;
         typedef nifty::array::StaticArray<uint32_t, DIM> CoordinateType;
         typedef nifty::array::StaticArray<float, DIM> FloatCoordinateType;
         typedef std::vector<CoordinateType> BaseType;
@@ -101,14 +101,14 @@ namespace cgp{
     };
 
 
-    template<size_t DIM, size_t CELL_TYPE>
+    template<std::size_t DIM, std::size_t CELL_TYPE>
     class CellGeometryVector  :
         public std::vector<CellGeometry<DIM, CELL_TYPE> > 
     {
 
     };
 
-    template<size_t DIM>
+    template<std::size_t DIM>
     class Geometry;
 
 
@@ -125,7 +125,7 @@ namespace cgp{
 
         Geometry(const TopologicalGridType & tGrid, const bool fill=false, const bool sort1Cells=true);
 
-        template<size_t CELL_TYPE>
+        template<std::size_t CELL_TYPE>
         const CellGeometryVector<2,CELL_TYPE> &
         geometry()const{
             return std::get<CELL_TYPE>(geometry_);

--- a/include/nifty/cgp/topological_grid.hxx
+++ b/include/nifty/cgp/topological_grid.hxx
@@ -17,7 +17,7 @@ namespace cgp{
 
 
 
-    template<size_t DIM>
+    template<std::size_t DIM>
     class TopologicalGrid;
 
 

--- a/include/nifty/features/accumulated_features.hxx
+++ b/include/nifty/features/accumulated_features.hxx
@@ -35,11 +35,11 @@ namespace features{
         typedef std::integral_constant<int, 1>  NPasses;
         typedef std::integral_constant<int, 11> NFeatures;
 
-        DefaultAccumulatedStatistics(const size_t rightTailCacheSize = 1000)
+        DefaultAccumulatedStatistics(const std::size_t rightTailCacheSize = 1000)
         :   acc_(bacc::right_tail_cache_size = rightTailCacheSize){
 
         }
-        DefaultAccumulatedStatistics & acc(const T & val, const size_t pass=0){
+        DefaultAccumulatedStatistics & acc(const T & val, const std::size_t pass=0){
             acc_(val);
             return *this;
         }
@@ -66,10 +66,10 @@ namespace features{
 
         }
 
-        size_t requiredPasses()const{
+        std::size_t requiredPasses()const{
             return 1;
         }
-        size_t nFeatures()const{
+        std::size_t nFeatures()const{
             return NFeatures::value;
         }
     private:

--- a/include/nifty/features/fastfilters_wrapper.hxx
+++ b/include/nifty/features/fastfilters_wrapper.hxx
@@ -22,10 +22,10 @@ namespace detail_fastfilters {
     template <> struct FastfiltersDim<fastfilters_array2d_t> {
         static const unsigned int ndim = 2;
     
-        static void set_z(size_t /*n_z*/, fastfilters_array2d_t /*&k*/)
+        static void set_z(std::size_t /*n_z*/, fastfilters_array2d_t /*&k*/)
         {
         }
-        static void set_stride_z(size_t /*n_z*/, fastfilters_array2d_t /*&k*/)
+        static void set_stride_z(std::size_t /*n_z*/, fastfilters_array2d_t /*&k*/)
         {
         }
     };
@@ -33,11 +33,11 @@ namespace detail_fastfilters {
     template <> struct FastfiltersDim<fastfilters_array3d_t> {
         static const unsigned int ndim = 3;
     
-        static void set_z(size_t n_z, fastfilters_array3d_t &k)
+        static void set_z(std::size_t n_z, fastfilters_array3d_t &k)
         {
             k.n_z = n_z;
         }
-        static void set_stride_z(size_t stride_z, fastfilters_array3d_t &k)
+        static void set_stride_z(std::size_t stride_z, fastfilters_array3d_t &k)
         {
             k.stride_z = stride_z;
         }
@@ -188,7 +188,7 @@ namespace detail_fastfilters {
             if( !fastfilters_fir_hog2d(&ff, sigma, xx, xy, yy, &opt_) ) 
                 throw std::runtime_error("HessianOfGaussian 2d failed.");
 
-            const size_t numberOfPixels = ff.n_x * ff.n_y;
+            const std::size_t numberOfPixels = ff.n_x * ff.n_y;
 
             float* ev0 = &out(0);
             float* ev1 = &out(0) + numberOfPixels;
@@ -212,7 +212,7 @@ namespace detail_fastfilters {
             if( !fastfilters_fir_hog3d(&ff, sigma, xx, yy, zz, xy, xz, yz, &opt_) ) 
                 throw std::runtime_error("HessianOfGaussian 3d failed.");
 
-            const size_t numberOfPixels = ff.n_x * ff.n_y * ff.n_z;
+            const std::size_t numberOfPixels = ff.n_x * ff.n_y * ff.n_z;
 
             float* ev0 = &out(0);
             float* ev1 = &out(0) + numberOfPixels;
@@ -253,7 +253,7 @@ namespace detail_fastfilters {
             if( !fastfilters_fir_structure_tensor2d(&ff, sigma, sigmaOuter_, xx, xy, yy, &opt_) ) 
                 throw std::runtime_error("StructurTensor 2d failed.");
 
-            const size_t numberOfPixels = ff.n_x * ff.n_y;
+            const std::size_t numberOfPixels = ff.n_x * ff.n_y;
 
             float* ev0 = &out(0);
             float* ev1 = &out(0) + numberOfPixels;
@@ -280,7 +280,7 @@ namespace detail_fastfilters {
             if( !fastfilters_fir_structure_tensor3d(&ff, sigma, 2*sigma, xx, yy, zz, xy, xz, yz, &opt_) ) 
                 throw std::runtime_error("StructureTensor 3d failed.");
 
-            const size_t numberOfPixels = ff.n_x * ff.n_y * ff.n_z;
+            const std::size_t numberOfPixels = ff.n_x * ff.n_y * ff.n_z;
 
             float* ev0 = &out(0);
             float* ev1 = &out(0) + numberOfPixels;
@@ -331,7 +331,7 @@ namespace detail_fastfilters {
             for(const auto & filtToSig : filtersToSigmas)
                 NIFTY_CHECK_OP(filtToSig.size(),==,sigmas_.size(),"");
             
-            for(size_t ii = 0; ii < filtersToSigmas_.size(); ++ii) {
+            for(std::size_t ii = 0; ii < filtersToSigmas_.size(); ++ii) {
                 // if at least one sigma is active, we push back the corresponding filter
                 const auto & filtToSig = filtersToSigmas_[ii];
                 bool hasSigma = false;
@@ -374,14 +374,14 @@ namespace detail_fastfilters {
             applyFiltersParallel(in, out, shapeSingleChannel, shapeMultiChannel, base, threadpool);
         }
 
-        size_t numberOfChannels() const {
-            size_t numberOfChannels = 0;
-            for( size_t ii = 0; ii < activeFilters_.size(); ++ii ) {
+        std::size_t numberOfChannels() const {
+            std::size_t numberOfChannels = 0;
+            for( std::size_t ii = 0; ii < activeFilters_.size(); ++ii ) {
                 if( !activeFilters_[ii] )
                     continue;
-                size_t nChans = filters_.at(ii)->isMultiChannel() ? DIM : 1;
+                std::size_t nChans = filters_.at(ii)->isMultiChannel() ? DIM : 1;
                 const auto & activeSigmas = filtersToSigmas_[ii];
-                for( size_t jj = 0; jj < sigmas_.size(); ++jj ) {
+                for( std::size_t jj = 0; jj < sigmas_.size(); ++jj ) {
                     if( activeSigmas[jj] )
                         numberOfChannels += nChans;
                 }
@@ -424,12 +424,12 @@ namespace detail_fastfilters {
             detail_fastfilters::convertMarray2ff(in, ff);
 
             // apply filters sequentially
-            for( size_t ii = 0; ii < activeFilters_.size(); ++ii ) {
+            for( std::size_t ii = 0; ii < activeFilters_.size(); ++ii ) {
                 if( !activeFilters_[ii] )
                     continue;
                 const auto & activeSigmas = filtersToSigmas_[ii];
                 auto & filter = filters_.at(ii);
-                for( size_t jj = 0; jj < sigmas_.size(); ++jj ) {
+                for( std::size_t jj = 0; jj < sigmas_.size(); ++jj ) {
                     if( !activeSigmas[jj] )
                         continue;
                     auto sigma = sigmas_[jj];
@@ -458,11 +458,11 @@ namespace detail_fastfilters {
             
             // determine start coordinates to run with presmoothing
             std::vector<std::vector<Coord>> bases(sigmas_.size());
-            for(size_t ii = 0; ii < bases.size(); ++ii)
+            for(std::size_t ii = 0; ii < bases.size(); ++ii)
                 bases[ii] = std::vector<Coord>(filtersToSigmas_.size());
             int64_t channelStart = 0;
-            for( size_t jj = 0; jj < filtersToSigmas_.size(); ++jj ) {
-                for( size_t ii = 0; ii < sigmas_.size(); ++ii ) {
+            for( std::size_t jj = 0; jj < filtersToSigmas_.size(); ++jj ) {
+                for( std::size_t ii = 0; ii < sigmas_.size(); ++ii ) {
                     if( !filtersToSigmas_[jj][ii] )
                         continue;
                     Coord channelBase = base;
@@ -473,7 +473,7 @@ namespace detail_fastfilters {
             }
 
             // iterate over sigmas and apply filters with pre smoothing
-            for(size_t ii = 0; ii < sigmas_.size(); ++ii) {
+            for(std::size_t ii = 0; ii < sigmas_.size(); ++ii) {
                 // determine the correct sigma for pre smoothing
                 double sigma = sigmas_[ii];
                 //std::cout << "Sigma: " << ii << " = " << sigma << std::endl; 
@@ -494,7 +494,7 @@ namespace detail_fastfilters {
                 }
 
                 // apply all filters for this sigma
-                for(size_t jj = 0; jj < filtersToSigmas_.size(); ++jj) {
+                for(std::size_t jj = 0; jj < filtersToSigmas_.size(); ++jj) {
                     if( !filtersToSigmas_[jj][ii] )
                         continue;
                     //std::cout << "Filter " << jj << std::endl;
@@ -520,14 +520,14 @@ namespace detail_fastfilters {
             detail_fastfilters::convertMarray2ff(in, ff);
             
             // determine start coordinates to run in parallel
-            std::vector<std::pair<size_t,double>> filterIdAndSigmas;
+            std::vector<std::pair<std::size_t,double>> filterIdAndSigmas;
             std::vector<Coord> bases;
             int64_t channelStart = 0;
-            for( size_t ii = 0; ii < activeFilters_.size(); ++ii ) {
+            for( std::size_t ii = 0; ii < activeFilters_.size(); ++ii ) {
                 if( !activeFilters_[ii] )
                     continue;
                 const auto & activeSigmas = filtersToSigmas_[ii];
-                for( size_t jj = 0; jj < sigmas_.size(); ++jj ) {
+                for( std::size_t jj = 0; jj < sigmas_.size(); ++jj ) {
                     if( !activeSigmas[jj] )
                         continue;
                     filterIdAndSigmas.push_back(std::make_pair(ii, sigmas_[jj]));
@@ -551,7 +551,7 @@ namespace detail_fastfilters {
 
         std::vector<double> sigmas_;
         FiltersToSigmasType filtersToSigmas_;
-        std::map<size_t,FilterBase*> filters_;
+        std::map<std::size_t,FilterBase*> filters_;
         std::array<bool,4> activeFilters_;
     };
     

--- a/include/nifty/filters/gaussian_curvature.hxx
+++ b/include/nifty/filters/gaussian_curvature.hxx
@@ -60,7 +60,7 @@ public:
             : coordinates_(_coordinates){
             }
             //
-            std::array<ValueType,2> operator[](const size_t i)const{
+            std::array<ValueType,2> operator[](const std::size_t i)const{
                 std::array<ValueType,2> ret;
                 ret[0] = coordinates_(i, 0);
                 ret[1] = coordinates_(i, 1);
@@ -72,7 +72,7 @@ public:
             OutAdaptor(const nifty::marray::View< T1 > & _out)
             : out_(_out){
             }
-            T0 & operator[](const size_t i)const{
+            T0 & operator[](const std::size_t i)const{
                 return out_(i);
             }
             const nifty::marray::View< T0 > & out_;
@@ -103,7 +103,7 @@ private:
     void impl(
         COORD_ITER coordsBegin,
         OUT_ITER   outIter,
-        const size_t size,
+        const std::size_t size,
         const bool closedLine
     ) const {
 
@@ -112,7 +112,7 @@ private:
         struct CoordinateExtrapolator{   
             CoordinateExtrapolator(
                 const COORD_ITER & _coordinates,
-                const size_t s
+                const std::size_t s
             ):  coordinates_(_coordinates),
                 size_(s)
             {
@@ -147,7 +147,7 @@ private:
             }
 
             const COORD_ITER & coordinates_;
-            size_t size_;
+            std::size_t size_;
             std::array<ValueType,2>  dLow_;
             std::array<ValueType,2>  dHigh_;
         };

--- a/include/nifty/graph/agglo/cluster_policies/mala_cluster_policy.hxx
+++ b/include/nifty/graph/agglo/cluster_policies/mala_cluster_policy.hxx
@@ -55,7 +55,7 @@ public:
 private:
 
     // internal types
-    const static size_t NumberOfBins = 20;
+    const static std::size_t NumberOfBins = 20;
     typedef std::array<float, NumberOfBins> HistogramType;     
     typedef typename GRAPH:: template EdgeMap<HistogramType> EdgeHistogramMap;
 
@@ -171,7 +171,7 @@ MalaClusterPolicy(
         edgeSizes_[edge] = size;
 
         // put in histogram
-        auto bin = std::min(size_t(val*float(NumberOfBins)), size_t(NumberOfBins-1));
+        auto bin = std::min(std::size_t(val*float(NumberOfBins)), std::size_t(NumberOfBins-1));
         auto & hist = histograms_[edge];
         std::fill(hist.begin(), hist.end(), 0.0);
         hist[bin] = size;

--- a/include/nifty/graph/bidirectional_breadth_first_search.hxx
+++ b/include/nifty/graph/bidirectional_breadth_first_search.hxx
@@ -68,7 +68,7 @@ namespace graph{
             backVec_.resize(0);
         }
 
-        const T & operator[](const size_t i) const{
+        const T & operator[](const std::size_t i) const{
             if(i < frontVec_.size()){
                 const auto j = frontVec_.size() - 1 - i;
             }
@@ -77,7 +77,7 @@ namespace graph{
             }
         }
         
-        size_t size()const{
+        std::size_t size()const{
             return frontVec_ + backVec_;
         }
     private:

--- a/include/nifty/graph/detail/search_impl.hxx
+++ b/include/nifty/graph/detail/search_impl.hxx
@@ -48,7 +48,7 @@ namespace detail_graph{
         template< class F>
         void graphNeighbourhood(            
             const uint64_t source,
-            const size_t maxDistance,
+            const std::size_t maxDistance,
             F && f
         ){
 

--- a/include/nifty/graph/graph_maps.hxx
+++ b/include/nifty/graph/graph_maps.hxx
@@ -52,44 +52,44 @@ struct MultibandNodeMap
 public:
     class Proxy{
     public:
-        Proxy(T * ptr, const size_t size)
+        Proxy(T * ptr, const std::size_t size)
         :   ptr_(ptr),
             size_(size){
         }
-        const T & operator[](const size_t i)const{
+        const T & operator[](const std::size_t i)const{
             return ptr_[i];
         }
-        T & operator[](const size_t i){
+        T & operator[](const std::size_t i){
             return ptr_[i];
         }
     private:
         T * ptr_;
-        size_t size_;
+        std::size_t size_;
     };
 
     class ConstProxy{
     public:
-        ConstProxy(const T * ptr, const size_t size)
+        ConstProxy(const T * ptr, const std::size_t size)
         :   ptr_(ptr),
             size_(size){
         }
-        const T & operator[](const size_t i)const{
+        const T & operator[](const std::size_t i)const{
             return ptr_[i];
         }
-        const T & operator[](const size_t i){
+        const T & operator[](const std::size_t i){
             return ptr_[i];
         }
     private:
         const T * ptr_;
-        size_t size_;
+        std::size_t size_;
     };
 
 
-    MultibandNodeMap( const G & g, const size_t nChannels)
+    MultibandNodeMap( const G & g, const std::size_t nChannels)
     :   nChannels_(nChannels),
         data_((g.nodeIdUpperBound()+1)*nChannels){
     }
-    MultibandNodeMap( const G & g, const size_t nChannels, const T & val)
+    MultibandNodeMap( const G & g, const std::size_t nChannels, const T & val)
     :   nChannels_(nChannels),
         data_((g.nodeIdUpperBound()+1)*nChannels, val){
     }
@@ -100,12 +100,12 @@ public:
     ConstProxy operator[](const uint64_t nodeIndex)const{
         return ConstProxy(data_.data() + nodeIndex*nChannels_, nChannels_);
     }
-    const size_t numberOfChannels()const{
+    const std::size_t numberOfChannels()const{
         return nChannels_;
     }
 private:
     std::vector<T> data_;
-    size_t nChannels_;
+    std::size_t nChannels_;
 };
 
 
@@ -124,13 +124,13 @@ public:
         :   array_(&array),
             node_(node){
         }
-        const_reference operator[](const size_t i)const{
+        const_reference operator[](const std::size_t i)const{
             return array_->operator()(node_, i);
         }
-        reference operator[](const size_t i){
+        reference operator[](const std::size_t i){
             return array_->operator()(node_, i);
         }
-        size_t size()const{
+        std::size_t size()const{
             return array_->shape(1);
         }
     private:
@@ -143,13 +143,13 @@ public:
         :   array_(&array),
             node_(node){
         }
-        const_reference operator[](const size_t i)const{
+        const_reference operator[](const std::size_t i)const{
             return array_->operator()(node_, i);
         }
-        const_reference operator[](const size_t i){
+        const_reference operator[](const std::size_t i){
             return array_->operator()(node_, i);
         }
-        size_t size()const{
+        std::size_t size()const{
             return array_->shape(1);
         }
     private:
@@ -172,12 +172,12 @@ public:
     ConstProxy operator[](const uint64_t nodeIndex)const{
         return ConstProxy(array_, nodeIndex);
     }
-    const size_t numberOfChannels()const{
+    const std::size_t numberOfChannels()const{
         return nChannels_;
     }
 private:
     const ARRAY & array_;
-    size_t nChannels_;
+    std::size_t nChannels_;
 };
 
 

--- a/include/nifty/graph/long_range_adjacency/accumulate_long_range_features.hxx
+++ b/include/nifty/graph/long_range_adjacency/accumulate_long_range_features.hxx
@@ -90,8 +90,8 @@ void accumulateLongRangeFeaturesWithAccChain(
     const bool affsToUpper = zDirection == 1;
 
     Coord2 sliceShape2({shape[1], shape[2]});
-    Coord3 sliceShape3({1LL, shape[1], shape[2]});
-    Coord4 sliceShape4({1LL, 1LL, shape[1], shape[2]});
+    Coord3 sliceShape3({int64_t(1), shape[1], shape[2]});
+    Coord4 sliceShape4({int64_t(1), int64_t(1), shape[1], shape[2]});
 
     const int pass = 1;
     {
@@ -114,7 +114,7 @@ void accumulateLongRangeFeaturesWithAccChain(
             }
             const std::size_t edgeOffset = adj.edgeOffset(slice);
 
-            Coord3 beginA({slice, 0LL, 0LL});
+            Coord3 beginA({slice, int64_t(0), int64_t(0)});
             Coord3 endA({slice + 1, shape[1], shape[2]});
 
             auto labelsA = labelsAStorage.getView(tid);
@@ -123,8 +123,8 @@ void accumulateLongRangeFeaturesWithAccChain(
 
             // initialize the affinity storage and coordinates
             auto affs = affinityStorage.getView(tid);
-            Coord4 beginAff({0LL, 0LL, 0LL, 0LL});
-            Coord4 endAff({0LL, 0LL, shape[1], shape[2]});
+            Coord4 beginAff({int64_t(0), int64_t(0), int64_t(0), int64_t(0)});
+            Coord4 endAff({int64_t(0), int64_t(0), shape[1], shape[2]});
 
             // init view for labelsB
             auto labelsB = labelsBStorage.getView(tid);
@@ -161,7 +161,7 @@ void accumulateLongRangeFeaturesWithAccChain(
                 auto affsSqueezed = affs.squeezedView();
 
                 // read upper labels
-                Coord3 beginB({targetSlice,   0LL,       0LL});
+                Coord3 beginB({targetSlice,   int64_t(0),       int64_t(0)});
                 Coord3 endB({targetSlice + 1, shape[1], shape[2]});
                 tools::readSubarray(labels, beginB, endB, labelsB);
                 auto labelsBSqueezed = labelsB.squeezedView();
@@ -239,7 +239,7 @@ void accumulateLongRangeFeatures(
                 featuresTemp(edge, 2+qi) = replaceIfNotFinite(quantiles[qi], mean);
         }
 
-        FeatCoord begin({int64_t(edgeOffset),0LL});
+        FeatCoord begin({int64_t(edgeOffset),int64_t(0)});
         FeatCoord end({edgeOffset+nEdges, nStats});
 
         tools::writeSubarray(featuresOut, begin, end, featuresTemp);

--- a/include/nifty/graph/long_range_adjacency/accumulate_long_range_features.hxx
+++ b/include/nifty/graph/long_range_adjacency/accumulate_long_range_features.hxx
@@ -19,9 +19,9 @@ void accumulateLongRangeFeaturesForSlice(
     const marray::View<typename ADJACENCY::LabelType> & labelsB,
     const marray::View<float> & affinities,
     const int pass,
-    const size_t slice,
-    const size_t targetSlice,
-    const size_t edgeOffset
+    const std::size_t slice,
+    const std::size_t targetSlice,
+    const std::size_t edgeOffset
 ) {
     typedef COORD Coord2;
     typedef typename vigra::MultiArrayShape<3>::type VigraCoord;
@@ -79,12 +79,12 @@ void accumulateLongRangeFeaturesWithAccChain(
     typedef EDGE_ACC_CHAIN EdgeAccChainType;
     typedef std::vector<EdgeAccChainType> EdgeAccChainVectorType;
 
-    const size_t actualNumberOfThreads = threadpool.nThreads();
+    const std::size_t actualNumberOfThreads = threadpool.nThreads();
 
     const auto & shape = adj.shape();
 
-    const size_t nSlices = shape[0] - 2;
-    const size_t nEdges = adj.numberOfEdges();
+    const std::size_t nSlices = shape[0] - 2;
+    const std::size_t nEdges = adj.numberOfEdges();
 
     // convention for zDirection: 1 -> affinties go to upper slices, 2 -> affinities go to lower slices
     const bool affsToUpper = zDirection == 1;
@@ -109,10 +109,10 @@ void accumulateLongRangeFeaturesWithAccChain(
             // init this accumulatore chain
             EdgeAccChainVectorType accChainVec(adj.numberOfEdgesInSlice(slice));
             // set minmax for accumulator chains
-            for(size_t edge = 0; edge < accChainVec.size(); ++edge){
+            for(std::size_t edge = 0; edge < accChainVec.size(); ++edge){
                 accChainVec[edge].setHistogramOptions(histoOptions);
             }
-            const size_t edgeOffset = adj.edgeOffset(slice);
+            const std::size_t edgeOffset = adj.edgeOffset(slice);
 
             Coord3 beginA({slice, 0LL, 0LL});
             Coord3 endA({slice + 1, shape[1], shape[2]});
@@ -130,7 +130,7 @@ void accumulateLongRangeFeaturesWithAccChain(
             auto labelsB = labelsBStorage.getView(tid);
 
             int64_t targetSlice;
-            size_t channel;
+            std::size_t channel;
             for(int64_t z = 2; z <= adj.range(); ++z) {
 
                 targetSlice = slice + z;
@@ -219,7 +219,7 @@ void accumulateLongRangeFeatures(
     // accumulator function
     auto accFunction = [&threadpool, &featuresOut](
         const std::vector<AccChainType> & edgeAccChainVec,
-        const size_t edgeOffset
+        const std::size_t edgeOffset
     ){
         using namespace vigra::acc;
         typedef array::StaticArray<int64_t, 2> FeatCoord;

--- a/include/nifty/graph/long_range_adjacency/accumulate_long_range_features.hxx
+++ b/include/nifty/graph/long_range_adjacency/accumulate_long_range_features.hxx
@@ -90,8 +90,8 @@ void accumulateLongRangeFeaturesWithAccChain(
     const bool affsToUpper = zDirection == 1;
 
     Coord2 sliceShape2({shape[1], shape[2]});
-    Coord3 sliceShape3({1L, shape[1], shape[2]});
-    Coord4 sliceShape4({1L, 1L, shape[1], shape[2]});
+    Coord3 sliceShape3({1LL, shape[1], shape[2]});
+    Coord4 sliceShape4({1LL, 1LL, shape[1], shape[2]});
 
     const int pass = 1;
     {
@@ -114,7 +114,7 @@ void accumulateLongRangeFeaturesWithAccChain(
             }
             const size_t edgeOffset = adj.edgeOffset(slice);
 
-            Coord3 beginA({slice, 0L, 0L});
+            Coord3 beginA({slice, 0LL, 0LL});
             Coord3 endA({slice + 1, shape[1], shape[2]});
 
             auto labelsA = labelsAStorage.getView(tid);
@@ -123,8 +123,8 @@ void accumulateLongRangeFeaturesWithAccChain(
 
             // initialize the affinity storage and coordinates
             auto affs = affinityStorage.getView(tid);
-            Coord4 beginAff({0L, 0L, 0L, 0L});
-            Coord4 endAff({0L, 0L, shape[1], shape[2]});
+            Coord4 beginAff({0LL, 0LL, 0LL, 0LL});
+            Coord4 endAff({0LL, 0LL, shape[1], shape[2]});
 
             // init view for labelsB
             auto labelsB = labelsBStorage.getView(tid);
@@ -161,7 +161,7 @@ void accumulateLongRangeFeaturesWithAccChain(
                 auto affsSqueezed = affs.squeezedView();
 
                 // read upper labels
-                Coord3 beginB({targetSlice,   0L,       0L});
+                Coord3 beginB({targetSlice,   0LL,       0LL});
                 Coord3 endB({targetSlice + 1, shape[1], shape[2]});
                 tools::readSubarray(labels, beginB, endB, labelsB);
                 auto labelsBSqueezed = labelsB.squeezedView();
@@ -239,7 +239,7 @@ void accumulateLongRangeFeatures(
                 featuresTemp(edge, 2+qi) = replaceIfNotFinite(quantiles[qi], mean);
         }
 
-        FeatCoord begin({int64_t(edgeOffset),0L});
+        FeatCoord begin({int64_t(edgeOffset),0LL});
         FeatCoord end({edgeOffset+nEdges, nStats});
 
         tools::writeSubarray(featuresOut, begin, end, featuresTemp);

--- a/include/nifty/graph/long_range_adjacency/long_range_adjacency.hxx
+++ b/include/nifty/graph/long_range_adjacency/long_range_adjacency.hxx
@@ -139,7 +139,7 @@ void LongRangeAdjacency<LABELS>::initAdjacency(const LABELS & labels, const std:
     // get the shape, number of slices and slice shapes
     const std::size_t nSlices = shape_[0];
     Coord2 sliceShape2({shape_[1], shape_[2]});
-    Coord sliceShape3({1LL, shape_[1], shape_[2]});
+    Coord sliceShape3({int64_t(1), shape_[1], shape_[2]});
 
     // threadpool and actual number of threads
     nifty::parallel::ThreadPool threadpool(numberOfThreads);
@@ -160,7 +160,7 @@ void LongRangeAdjacency<LABELS>::initAdjacency(const LABELS & labels, const std:
             //std::cout << "Loop in " << slice << std::endl;
 
             // get segmentation in base slice
-            Coord beginA ({int64_t(slice), 0LL, 0LL});
+            Coord beginA ({int64_t(slice), int64_t(0), int64_t(0)});
             Coord endA({int64_t(slice + 1), shape_[1], shape_[2]});
             auto labelsA = labelsAStorage.getView(tid);
             tools::readSubarray(labels, beginA, endA, labelsA);
@@ -197,7 +197,7 @@ void LongRangeAdjacency<LABELS>::initAdjacency(const LABELS & labels, const std:
                 //std::cout << "to upper slice " << slice + z << std::endl;
 
                 // get upper segmentation
-                Coord beginB ({slice + z, 0LL, 0LL});
+                Coord beginB ({slice + z, int64_t(0), int64_t(0)});
                 Coord endB({slice + z + 1, shape_[1], shape_[2]});
                 tools::readSubarray(labels, beginB, endB, labelsB);
                 auto labelsBSqueezed = labelsB.squeezedView();

--- a/include/nifty/graph/long_range_adjacency/long_range_adjacency.hxx
+++ b/include/nifty/graph/long_range_adjacency/long_range_adjacency.hxx
@@ -139,7 +139,7 @@ void LongRangeAdjacency<LABELS>::initAdjacency(const LABELS & labels, const size
     // get the shape, number of slices and slice shapes
     const size_t nSlices = shape_[0];
     Coord2 sliceShape2({shape_[1], shape_[2]});
-    Coord sliceShape3({1L, shape_[1], shape_[2]});
+    Coord sliceShape3({1LL, shape_[1], shape_[2]});
 
     // threadpool and actual number of threads
     nifty::parallel::ThreadPool threadpool(numberOfThreads);
@@ -160,7 +160,7 @@ void LongRangeAdjacency<LABELS>::initAdjacency(const LABELS & labels, const size
             //std::cout << "Loop in " << slice << std::endl;
 
             // get segmentation in base slice
-            Coord beginA ({int64_t(slice), 0L, 0L});
+            Coord beginA ({int64_t(slice), 0LL, 0LL});
             Coord endA({int64_t(slice + 1), shape_[1], shape_[2]});
             auto labelsA = labelsAStorage.getView(tid);
             tools::readSubarray(labels, beginA, endA, labelsA);
@@ -197,7 +197,7 @@ void LongRangeAdjacency<LABELS>::initAdjacency(const LABELS & labels, const size
                 //std::cout << "to upper slice " << slice + z << std::endl;
 
                 // get upper segmentation
-                Coord beginB ({slice + z, 0L, 0L});
+                Coord beginB ({slice + z, 0LL, 0LL});
                 Coord endB({slice + z + 1, shape_[1], shape_[2]});
                 tools::readSubarray(labels, beginB, endB, labelsB);
                 auto labelsBSqueezed = labelsB.squeezedView();

--- a/include/nifty/graph/long_range_adjacency/long_range_adjacency.hxx
+++ b/include/nifty/graph/long_range_adjacency/long_range_adjacency.hxx
@@ -21,8 +21,8 @@ public:
     // constructor from data
     LongRangeAdjacency(
         const Labels & labels,
-        const size_t range,
-        const size_t numberOfLabels,
+        const std::size_t range,
+        const std::size_t numberOfLabels,
         const bool ignoreLabel,
         const int numberOfThreads=-1
     ) : range_(range),
@@ -50,26 +50,26 @@ public:
 
     // API
 
-    size_t range() const {
+    std::size_t range() const {
         return range_;
     }
 
-    size_t numberOfEdgesInSlice(const size_t z) const {
+    std::size_t numberOfEdgesInSlice(const std::size_t z) const {
         return numberOfEdgesInSlice_[z];
     }
 
-    size_t edgeOffset(const size_t z) const {
+    std::size_t edgeOffset(const std::size_t z) const {
         return edgeOffset_[z];
     }
 
-    size_t serializationSize() const {
-        size_t size = BaseType::serializationSize();
+    std::size_t serializationSize() const {
+        std::size_t size = BaseType::serializationSize();
         size += 2; // increase by 2 for the fields longRange and ignoreLabel
         size += shape_[0] * 2; // increase by slice vector sizes
         return size;
     }
 
-    int64_t shape(const size_t i) const {
+    int64_t shape(const std::size_t i) const {
         return shape_[i];
     }
 
@@ -83,8 +83,8 @@ public:
         ++iter;
         *iter = ignoreLabel_ ? 1 : 0;
         ++iter;
-        size_t nSlices = shape_[0];
-        for(size_t slice = 0; slice < nSlices; ++slice) {
+        std::size_t nSlices = shape_[0];
+        for(std::size_t slice = 0; slice < nSlices; ++slice) {
             *iter = numberOfEdgesInSlice_[slice];
             ++iter;
             *iter = edgeOffset_[slice];
@@ -98,7 +98,7 @@ public:
     }
 
 private:
-    void initAdjacency(const Labels & labels, const size_t numberOfLabels, const int numberOfThreads);
+    void initAdjacency(const Labels & labels, const std::size_t numberOfLabels, const int numberOfThreads);
 
     template<class ITER>
     void deserializeAdjacency(ITER & iter) {
@@ -106,8 +106,8 @@ private:
         ++iter;
         ignoreLabel_ = (*iter == 1) ? true : false;
         ++iter;
-        size_t nSlices = shape_[0];
-        for(size_t slice = 0; slice < nSlices; ++slice) {
+        std::size_t nSlices = shape_[0];
+        for(std::size_t slice = 0; slice < nSlices; ++slice) {
             numberOfEdgesInSlice_[slice] = *iter;
             ++iter;
             edgeOffset_[slice] = *iter;
@@ -117,16 +117,16 @@ private:
     }
 
     Coord shape_;
-    size_t range_;
-    std::vector<size_t> numberOfEdgesInSlice_;
-    std::vector<size_t> edgeOffset_;
+    std::size_t range_;
+    std::vector<std::size_t> numberOfEdgesInSlice_;
+    std::vector<std::size_t> edgeOffset_;
     bool ignoreLabel_;
 };
 
 
 // FIXME multithreading sometimes causes segfaults / undefined behaviour, if we have an ignore label
 template<class LABELS>
-void LongRangeAdjacency<LABELS>::initAdjacency(const LABELS & labels, const size_t numberOfLabels, const int numberOfThreads) {
+void LongRangeAdjacency<LABELS>::initAdjacency(const LABELS & labels, const std::size_t numberOfLabels, const int numberOfThreads) {
 
     typedef tools::BlockStorage<LabelType> LabelStorage;
     //std::cout << "Start" << std::endl;
@@ -137,13 +137,13 @@ void LongRangeAdjacency<LABELS>::initAdjacency(const LABELS & labels, const size
     BaseType::assign(numberOfLabels);
 
     // get the shape, number of slices and slice shapes
-    const size_t nSlices = shape_[0];
+    const std::size_t nSlices = shape_[0];
     Coord2 sliceShape2({shape_[1], shape_[2]});
     Coord sliceShape3({1LL, shape_[1], shape_[2]});
 
     // threadpool and actual number of threads
     nifty::parallel::ThreadPool threadpool(numberOfThreads);
-    const size_t nThreads = threadpool.nThreads();
+    const std::size_t nThreads = threadpool.nThreads();
 
     std::vector<LabelType> minNodeInSlice(nSlices, numberOfLabels + 1);
     std::vector<LabelType> maxNodeInSlice(nSlices);
@@ -223,10 +223,10 @@ void LongRangeAdjacency<LABELS>::initAdjacency(const LABELS & labels, const size
     //std::cout << "Loop done" << std::endl;
 
     // set up the edge offsets
-    size_t offset = numberOfEdgesInSlice_[0];
+    std::size_t offset = numberOfEdgesInSlice_[0];
     {
         edgeOffset_[0] = 0;
-        for(size_t slice = 1; slice < nSlices-2; ++slice) {
+        for(std::size_t slice = 1; slice < nSlices-2; ++slice) {
             edgeOffset_[slice] = offset;
             offset += numberOfEdgesInSlice_[slice];
         }

--- a/include/nifty/graph/opt/common/cc_fusion_move_based_impl.hxx
+++ b/include/nifty/graph/opt/common/cc_fusion_move_based_impl.hxx
@@ -69,8 +69,8 @@ namespace detail_cc_fusion{
 
         struct SettingsType{
             std::shared_ptr<ProposalGeneratorFactoryBaseType> proposalGeneratorFactory;
-            size_t numberOfIterations{1000};
-            size_t stopIfNoImprovement{10};
+            std::size_t numberOfIterations{1000};
+            std::size_t stopIfNoImprovement{10};
             int numberOfThreads{1};
             int numberOfParallelProposals{-1};
             FusionMoveSettingsType fusionMoveSettings;
@@ -273,7 +273,7 @@ namespace detail_cc_fusion{
 
             nifty::parallel::parallel_foreach(threadPool_,
                 settings_.numberOfParallelProposals,
-                [&](const size_t threadId, int proposalIndex){
+                [&](const std::size_t threadId, int proposalIndex){
 
                     
                     NodeLabelsType currentBestBuffer(graph_);

--- a/include/nifty/graph/opt/common/proposal_generators/greedy_additive_multicut_proposal_generator.hxx
+++ b/include/nifty/graph/opt/common/proposal_generators/greedy_additive_multicut_proposal_generator.hxx
@@ -60,7 +60,7 @@ namespace common{
 
         GreedyAdditiveMulticutProposals(
             const ObjectiveType & objective, 
-            const size_t numberOfThreads,
+            const std::size_t numberOfThreads,
             const SettingsType & settings  = SettingsType()
         )
         :   objective_(objective),
@@ -105,7 +105,7 @@ namespace common{
         virtual void generateProposal(
             const ProposalType & currentBest, 
             ProposalType & proposal, 
-            const size_t tid
+            const std::size_t tid
         ){
             
             if(negativeEdges_.empty()){
@@ -122,11 +122,11 @@ namespace common{
                 }
 
                 auto nSeeds = settings_.numberOfSeeds <=1.0 ? 
-                    size_t(float(graph.numberOfNodes())*settings_.numberOfSeeds+0.5f) :
-                    size_t(settings_.numberOfSeeds + 0.5);
+                    std::size_t(float(graph.numberOfNodes())*settings_.numberOfSeeds+0.5f) :
+                    std::size_t(settings_.numberOfSeeds + 0.5);
 
-                nSeeds = std::max(size_t(1),nSeeds);
-                nSeeds = std::min(size_t(negativeEdges_.size()-1), nSeeds);
+                nSeeds = std::max(std::size_t(1),nSeeds);
+                nSeeds = std::min(std::size_t(negativeEdges_.size()-1), nSeeds);
 
 
                 const auto & weights = objective_.weights();
@@ -135,7 +135,7 @@ namespace common{
                 });
 
 
-                for(size_t i=0; i <  (nSeeds == 1 ? 1 : nSeeds/2); ++i){
+                for(std::size_t i=0; i <  (nSeeds == 1 ? 1 : nSeeds/2); ++i){
                     const auto randIndex = intDist_(gen);
                     const auto edge  = negativeEdges_[randIndex];
                     const auto uv = graph.uv(edge);
@@ -152,7 +152,7 @@ namespace common{
         }
     private:
         const ObjectiveType & objective_;
-        size_t numberOfThreads_;
+        std::size_t numberOfThreads_;
         SettingsType settings_;
         std::vector<uint64_t> negativeEdges_;
         EdgeWeights noisyEdgeWeights_;

--- a/include/nifty/graph/opt/common/proposal_generators/interface_flipper_proposal_generator.hxx
+++ b/include/nifty/graph/opt/common/proposal_generators/interface_flipper_proposal_generator.hxx
@@ -36,7 +36,7 @@ namespace common{
 
         InterfaceFlipperProposalGenerator(
             const ObjectiveType & objective, 
-            const size_t numberOfThreads,
+            const std::size_t numberOfThreads,
             const SettingsType & settings  = SettingsType()
         )
         :   objective_(objective),
@@ -64,7 +64,7 @@ namespace common{
         virtual void generateProposal(
             const ProposalType & currentBest, 
             ProposalType & proposal, 
-            const size_t tid
+            const std::size_t tid
         ){  
 
             const auto & graph = objective_.graph();
@@ -102,7 +102,7 @@ namespace common{
         }
     private:
         const ObjectiveType & objective_;
-        size_t numberOfThreads_;
+        std::size_t numberOfThreads_;
         SettingsType settings_;
         std::vector<std::mt19937> gens_;
         std::vector< std::unique_ptr<IsUsed> > isUsedVec_;

--- a/include/nifty/graph/opt/common/proposal_generators/proposal_generator_base.hxx
+++ b/include/nifty/graph/opt/common/proposal_generators/proposal_generator_base.hxx
@@ -14,7 +14,7 @@ namespace common{
         typedef OBJECTIVE ObjectiveType;
         typedef typename ObjectiveType::GraphType:: template NodeMap<uint64_t> ProposalType;
         virtual ~ProposalGeneratorBase(){}
-        virtual void generateProposal( const ProposalType & currentBest,ProposalType & labels, const size_t tid) = 0;
+        virtual void generateProposal( const ProposalType & currentBest,ProposalType & labels, const std::size_t tid) = 0;
     }; 
 
     

--- a/include/nifty/graph/opt/common/proposal_generators/proposal_generator_factory.hxx
+++ b/include/nifty/graph/opt/common/proposal_generators/proposal_generator_factory.hxx
@@ -31,10 +31,10 @@ namespace common{
 
         virtual ~ProposalGeneratorFactory(){}
 
-        virtual std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective,  const size_t numberOfThreads){
+        virtual std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective,  const std::size_t numberOfThreads){
             return std::make_shared<ProposalGeneratorType>(objective, numberOfThreads, settings_);
         }
-        virtual ProposalGeneratorBaseType *                create(   const ObjectiveType & objective,  const size_t numberOfThreads){
+        virtual ProposalGeneratorBaseType *                create(   const ObjectiveType & objective,  const std::size_t numberOfThreads){
             return new ProposalGeneratorType(objective, numberOfThreads, settings_);
         }
     private:

--- a/include/nifty/graph/opt/common/proposal_generators/proposal_generator_factory_base.hxx
+++ b/include/nifty/graph/opt/common/proposal_generators/proposal_generator_factory_base.hxx
@@ -19,8 +19,8 @@ namespace common{
         typedef ProposalGeneratorBase<ObjectiveType> ProposalGeneratorBaseType;
 
         virtual ~ProposalGeneratorFactoryBase(){}
-        virtual std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective, const size_t numberOfThreads) = 0;
-        virtual ProposalGeneratorBaseType *                create(   const ObjectiveType & objective, const size_t numberOfThreads) = 0;
+        virtual std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective, const std::size_t numberOfThreads) = 0;
+        virtual ProposalGeneratorBaseType *                create(   const ObjectiveType & objective, const std::size_t numberOfThreads) = 0;
     };
 
 

--- a/include/nifty/graph/opt/common/proposal_generators/random_node_color_proposal_generator.hxx
+++ b/include/nifty/graph/opt/common/proposal_generators/random_node_color_proposal_generator.hxx
@@ -30,12 +30,12 @@ namespace common{
         typedef typename GraphType:: template NodeMap<bool>  IsUsed;    
             
         struct SettingsType{
-            size_t numberOfColors{size_t(2)};
+            std::size_t numberOfColors{std::size_t(2)};
         };
 
         RandomNodeColorProposalGenerator(
             const ObjectiveType & objective, 
-            const size_t numberOfThreads,
+            const std::size_t numberOfThreads,
             const SettingsType & settings  = SettingsType()
         )
         :   objective_(objective),
@@ -58,7 +58,7 @@ namespace common{
         virtual void generateProposal(
             const ProposalType & currentBest, 
             ProposalType & proposal, 
-            const size_t tid
+            const std::size_t tid
         ){  
 
             const auto & graph = objective_.graph();
@@ -73,7 +73,7 @@ namespace common{
         }
     private:
         const ObjectiveType & objective_;
-        size_t numberOfThreads_;
+        std::size_t numberOfThreads_;
         SettingsType settings_;
         std::vector<std::mt19937> gens_;
         std::uniform_int_distribution<>  colorDist_;

--- a/include/nifty/graph/opt/common/proposal_generators/stub_proposal_generator.hxx
+++ b/include/nifty/graph/opt/common/proposal_generators/stub_proposal_generator.hxx
@@ -34,7 +34,7 @@ namespace common{
 
         StubProposalGenerator(
             const ObjectiveType & objective, 
-            const size_t numberOfThreads,
+            const std::size_t numberOfThreads,
             const SettingsType & settings  = SettingsType()
         )
         :   objective_(objective),
@@ -51,13 +51,13 @@ namespace common{
         virtual void generateProposal(
             const ProposalType & currentBest, 
             ProposalType & proposal, 
-            const size_t tid
+            const std::size_t tid
         ){
             
         }
     private:
         const ObjectiveType & objective_;
-        size_t numberOfThreads_;
+        std::size_t numberOfThreads_;
         SettingsType settings_;
     }; 
 

--- a/include/nifty/graph/opt/common/proposal_generators/watershed_proposal_generator.hxx
+++ b/include/nifty/graph/opt/common/proposal_generators/watershed_proposal_generator.hxx
@@ -44,7 +44,7 @@ namespace common{
 
         WatershedProposalGenerator(
             const ObjectiveType & objective, 
-            const size_t numberOfThreads,
+            const std::size_t numberOfThreads,
             const SettingsType & settings  = SettingsType()
         )
         :   objective_(objective),
@@ -89,7 +89,7 @@ namespace common{
         virtual void generateProposal(
             const ProposalType & currentBest, 
             ProposalType & proposal, 
-            const size_t tid
+            const std::size_t tid
         ){
             
             if(negativeEdges_.empty()){
@@ -106,11 +106,11 @@ namespace common{
                 }
 
                 auto nSeeds = settings_.numberOfSeeds <=1.0 ? 
-                    size_t(float(graph.numberOfNodes())*settings_.numberOfSeeds+0.5f) :
-                    size_t(settings_.numberOfSeeds + 0.5);
+                    std::size_t(float(graph.numberOfNodes())*settings_.numberOfSeeds+0.5f) :
+                    std::size_t(settings_.numberOfSeeds + 0.5);
 
-                nSeeds = std::max(size_t(1),nSeeds);
-                nSeeds = std::min(size_t(negativeEdges_.size()-1), nSeeds);
+                nSeeds = std::max(std::size_t(1),nSeeds);
+                nSeeds = std::min(std::size_t(negativeEdges_.size()-1), nSeeds);
 
 
                 const auto & weights = objective_.weights();
@@ -119,7 +119,7 @@ namespace common{
                 });
 
 
-                for(size_t i=0; i <  (nSeeds == 1 ? 1 : nSeeds/2); ++i){
+                for(std::size_t i=0; i <  (nSeeds == 1 ? 1 : nSeeds/2); ++i){
                     const auto randIndex = intDist_(gen);
                     const auto edge  = negativeEdges_[randIndex];
                     const auto uv = graph.uv(edge);
@@ -136,7 +136,7 @@ namespace common{
         }
     private:
         const ObjectiveType & objective_;
-        size_t numberOfThreads_;
+        std::size_t numberOfThreads_;
         SettingsType settings_;
         std::vector<uint64_t> negativeEdges_;
         EdgeWeights noisyEdgeWeights_;

--- a/include/nifty/graph/opt/common/visitor_base.hxx
+++ b/include/nifty/graph/opt/common/visitor_base.hxx
@@ -85,7 +85,7 @@ namespace common{
                 ss << "Energy: " << std::scientific << solver->currentBestEnergy()<<" ";
                 ss << "Runtime: " << runtime_ << " ";
                 
-                for(size_t i=0; i<logNames_.size(); ++i){
+                for(std::size_t i=0; i<logNames_.size(); ++i){
                     ss<<logNames_[i]<<" "<<logValues_[i]<<" ";
                 }
                 ss<<"\n";
@@ -109,7 +109,7 @@ namespace common{
             logValues_.resize(logNames.size());
         }
 
-        virtual void setLogValue(const size_t logIndex, double logValue){
+        virtual void setLogValue(const std::size_t logIndex, double logValue){
             logValues_[logIndex] = logValue;
         }
 
@@ -128,7 +128,7 @@ namespace common{
 
         double timeLimit_;
         TimePointType startTime_;
-        size_t runtime_;
+        std::size_t runtime_;
 
         std::vector<std::string> logNames_;
         std::vector<double> logValues_;

--- a/include/nifty/graph/opt/higher_order_multicut/higher_order_multicut_objective.hxx
+++ b/include/nifty/graph/opt/higher_order_multicut/higher_order_multicut_objective.hxx
@@ -19,7 +19,7 @@ namespace higher_order_multicut{
             
 
 
-        size_t arity()const{
+        std::size_t arity()const{
             return edgeIds_.size();
         }
         const std::vector<uint64_t> & edgeIds(){

--- a/include/nifty/graph/opt/lifted_multicut/fusion_move_based.hxx
+++ b/include/nifty/graph/opt/lifted_multicut/fusion_move_based.hxx
@@ -72,8 +72,8 @@ namespace lifted_multicut{
 
         struct SettingsType{
             std::shared_ptr<ProposalGeneratorFactoryBaseType> proposalGeneratorFactory;
-            size_t numberOfIterations{1000};
-            size_t stopIfNoImprovement{10};
+            std::size_t numberOfIterations{1000};
+            std::size_t stopIfNoImprovement{10};
             int numberOfThreads{1};
         };
 

--- a/include/nifty/graph/opt/lifted_multicut/lifted_graph_features.hxx
+++ b/include/nifty/graph/opt/lifted_multicut/lifted_graph_features.hxx
@@ -67,7 +67,7 @@ namespace lifted_multicut{
         EdgeMapDouble lgOutBuffer(liftedGraph);
 
         auto fi = 0;
-        for(size_t i=0; i<sizeRegularizers.size(); ++i){
+        for(std::size_t i=0; i<sizeRegularizers.size(); ++i){
 
             // reset / fill maps
             graph.forEachEdge([&](const uint64_t graphEdge){
@@ -171,7 +171,7 @@ namespace lifted_multicut{
             const double offset_;
         };
 
-        for(size_t i=0; i<offsets.size(); ++i){
+        for(std::size_t i=0; i<offsets.size(); ++i){
 
             // run the shortest path algorithm
             objective.parallelForEachLiftedeEdge(threadpool,

--- a/include/nifty/graph/opt/lifted_multicut/lifted_multicut_ilp.hxx
+++ b/include/nifty/graph/opt/lifted_multicut/lifted_multicut_ilp.hxx
@@ -69,7 +69,7 @@ namespace lifted_multicut{
 
         struct SettingsType{
 
-            size_t numberOfIterations{0};
+            std::size_t numberOfIterations{0};
             int verbose { 0 };
             bool verboseIlp{false};
             bool addThreeCyclesConstraints{true};
@@ -123,7 +123,7 @@ namespace lifted_multicut{
         void repairSolution(NodeLabelsType & nodeLabels);
 
 
-        size_t addViolatedInequalities(const bool searchForCutConstraitns, VisitorProxyType & visitor);
+        std::size_t addViolatedInequalities(const bool searchForCutConstraitns, VisitorProxyType & visitor);
         void addThreeCyclesConstraintsExplicitly();
 
         const Objective & objective_;
@@ -139,11 +139,11 @@ namespace lifted_multicut{
         BidirectionalBreadthFirstSearch<Graph> bibfs_;
         DfsType dfs_;
         SettingsType settings_;
-        std::vector<size_t> variables_;
+        std::vector<std::size_t> variables_;
         std::vector<double> coefficients_;
         NodeLabelsType * currentBest_;
-        size_t addedConstraints_;
-        size_t numberOfOptRuns_;
+        std::size_t addedConstraints_;
+        std::size_t numberOfOptRuns_;
     };
 
     
@@ -214,7 +214,7 @@ namespace lifted_multicut{
             ilpSolver_->setStart(edgeLabelIter);
 
 
-            size_t i=0;
+            std::size_t i=0;
             for (  ; settings_.numberOfIterations == 0 || i < settings_.numberOfIterations; ++i){
 
 
@@ -281,7 +281,7 @@ namespace lifted_multicut{
     }
 
     template<class OBJECTIVE, class ILP_SOLVER>
-    size_t LiftedMulticutIlp<OBJECTIVE, ILP_SOLVER>::
+    std::size_t LiftedMulticutIlp<OBJECTIVE, ILP_SOLVER>::
     addViolatedInequalities(
         const bool searchForCutConstraitns,
         VisitorProxyType & visitorProxy
@@ -295,8 +295,8 @@ namespace lifted_multicut{
 
         // search for violated non-chordal cycles and add corresp. inequalities
         // and for violated cut constraints
-        size_t nCycleConstraints = 0;
-        size_t nCutConstraints = 0;
+        std::size_t nCycleConstraints = 0;
+        std::size_t nCutConstraints = 0;
 
         // we iterate over edges and the corresponding lpEdge 
         // for a graph with dense contiguous edge ids the lpEdge 
@@ -324,7 +324,7 @@ namespace lifted_multicut{
                 }
 
                 if(chordless){
-                    for (size_t j = 0; j < sz - 1; ++j){
+                    for (std::size_t j = 0; j < sz - 1; ++j){
                         const auto v = denseIds_[liftedGraph_.findEdge(path[j], path[j + 1])];
                         NIFTY_ASSERT_OP(v,<,liftedGraph_.numberOfEdges());
                         variables_[j] = v;
@@ -435,7 +435,7 @@ namespace lifted_multicut{
     addThreeCyclesConstraintsExplicitly(
     ){
         
-        std::array<size_t, 3> variables;
+        std::array<std::size_t, 3> variables;
         std::array<double, 3> coefficients;
         auto threeCycles = findThreeCyclesEdges(graph_);
         auto c = 0;

--- a/include/nifty/graph/opt/lifted_multicut/lifted_multicut_kernighan_lin.hxx
+++ b/include/nifty/graph/opt/lifted_multicut/lifted_multicut_kernighan_lin.hxx
@@ -165,7 +165,7 @@ namespace lifted_multicut{
         }
 
         // interatively update bipartition in order to minimize the total cost of the multicut
-        for (size_t k = 0; k < settings_.numberOfOuterIterations; ++k){
+        for (std::size_t k = 0; k < settings_.numberOfOuterIterations; ++k){
 
 
             auto energyDecrease = 0.0;

--- a/include/nifty/graph/opt/lifted_multicut/lifted_multicut_mp.hxx
+++ b/include/nifty/graph/opt/lifted_multicut/lifted_multicut_mp.hxx
@@ -62,11 +62,11 @@ namespace lifted_multicut{
                 std::vector<char> labeling(edgeValues.size(), 0);
                 if(originalGraph.numberOfEdges() > 0) {
                     
-                    const size_t nLocalEdges = originalGraph.numberOfEdges();
+                    const std::size_t nLocalEdges = originalGraph.numberOfEdges();
                     PrimalRounderObjectiveType obj(originalGraph);
 
                     // insert local costs
-                    size_t edgeId = 0;
+                    std::size_t edgeId = 0;
                     for(;edgeId < nLocalEdges; ++edgeId) {
                         const auto & uv = originalGraph.uv(edgeId);
                         obj.setCost(uv.first, uv.second, edgeValues[edgeId]);
@@ -127,23 +127,23 @@ namespace lifted_multicut{
             bool greedyWarmstart{true};
             // parameters for lp_mp solver TODO need better (non-completely-guessed...) default values
             double tightenSlope{0.05};
-            size_t tightenMinDualImprovementInterval{0};
+            std::size_t tightenMinDualImprovementInterval{0};
             double tightenMinDualImprovement{0.};
             double tightenConstraintsPercentage{0.1};
-            size_t tightenConstraintsMax{0};
-            size_t tightenInterval{10};
-            size_t tightenIteration{100};
+            std::size_t tightenConstraintsMax{0};
+            std::size_t tightenInterval{10};
+            std::size_t tightenIteration{100};
             std::string tightenReparametrization{"anisotropic"};
             std::string roundingReparametrization{"anisotropic"};
             std::string standardReparametrization{"anisotropic"};
             bool tighten{true};
-            size_t minDualImprovementInterval{0};
+            std::size_t minDualImprovementInterval{0};
             double minDualImprovement{0.};
-            size_t lowerBoundComputationInterval{1};
-            size_t primalComputationInterval{5};
-            size_t timeout{0};
-            size_t maxIter{1000};
-            size_t numLpThreads{1};
+            std::size_t lowerBoundComputationInterval{1};
+            std::size_t primalComputationInterval{5};
+            std::size_t timeout{0};
+            std::size_t maxIter{1000};
+            std::size_t numLpThreads{1};
         };
             
         LiftedMulticutMp(const ObjectiveType & objective, const SettingsType & settings = SettingsType());
@@ -215,8 +215,8 @@ namespace lifted_multicut{
             auto & constructor = (*mpSolver_).template GetProblemConstructor<0>();
             const auto & weights = objective_.weights();
 
-            const size_t nLocalEdges = graph_.numberOfEdges();
-            size_t edgeId = 0;
+            const std::size_t nLocalEdges = graph_.numberOfEdges();
+            std::size_t edgeId = 0;
             for(;edgeId < nLocalEdges; ++edgeId) {
                 const auto & uv = graph_.uv(edgeId);
                 constructor.AddUnaryFactor(uv.first, uv.second, weights[edgeId]);

--- a/include/nifty/graph/opt/lifted_multicut/proposal_generators/proposal_generator_base.hxx
+++ b/include/nifty/graph/opt/lifted_multicut/proposal_generators/proposal_generator_base.hxx
@@ -23,7 +23,7 @@ namespace lifted_multicut{
     
         virtual ~ProposalGeneratorBase(){}
 
-        virtual void generateProposal( const NodeLabelsType & currentBest,NodeLabelsType & labels, const size_t tid) = 0;
+        virtual void generateProposal( const NodeLabelsType & currentBest,NodeLabelsType & labels, const std::size_t tid) = 0;
 
     private:
     }; 

--- a/include/nifty/graph/opt/lifted_multicut/proposal_generators/proposal_generator_factory.hxx
+++ b/include/nifty/graph/opt/lifted_multicut/proposal_generators/proposal_generator_factory.hxx
@@ -28,10 +28,10 @@ namespace lifted_multicut{
 
         virtual ~ProposalGeneratorFactory(){}
 
-        virtual std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective,  const size_t numberOfThreads){
+        virtual std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective,  const std::size_t numberOfThreads){
             return std::make_shared<ProposalGeneratorType>(objective, numberOfThreads, settings_);
         }
-        virtual ProposalGeneratorBaseType *                create(   const ObjectiveType & objective,  const size_t numberOfThreads){
+        virtual ProposalGeneratorBaseType *                create(   const ObjectiveType & objective,  const std::size_t numberOfThreads){
             return new ProposalGeneratorType(objective, numberOfThreads, settings_);
         }
     private:

--- a/include/nifty/graph/opt/lifted_multicut/proposal_generators/proposal_generator_factory_base.hxx
+++ b/include/nifty/graph/opt/lifted_multicut/proposal_generators/proposal_generator_factory_base.hxx
@@ -20,8 +20,8 @@ namespace lifted_multicut{
         typedef ProposalGeneratorBase<ObjectiveType> ProposalGeneratorBaseType;
 
         virtual ~ProposalGeneratorFactoryBase(){}
-        virtual std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective, const size_t numberOfThreads) = 0;
-        virtual ProposalGeneratorBaseType *                create(   const ObjectiveType & objective, const size_t numberOfThreads) = 0;
+        virtual std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective, const std::size_t numberOfThreads) = 0;
+        virtual ProposalGeneratorBaseType *                create(   const ObjectiveType & objective, const std::size_t numberOfThreads) = 0;
     };
 
 

--- a/include/nifty/graph/opt/lifted_multicut/proposal_generators/watershed_proposal_generator.hxx
+++ b/include/nifty/graph/opt/lifted_multicut/proposal_generators/watershed_proposal_generator.hxx
@@ -44,7 +44,7 @@ namespace lifted_multicut{
 
         WatershedProposalGenerator(
             const ObjectiveType & objective, 
-            const size_t numberOfThreads,
+            const std::size_t numberOfThreads,
             const SettingsType & settings  = SettingsType()
         )
         :   objective_(objective),
@@ -124,7 +124,7 @@ namespace lifted_multicut{
 
         virtual void generateProposal(
             const NodeLabelsType & currentBest,NodeLabelsType & proposal, 
-            const size_t tid
+            const std::size_t tid
         ){
             
             if(negativeEdges_.empty()){
@@ -140,11 +140,11 @@ namespace lifted_multicut{
                 NodeLabelsType  seeds(graph, 0);
 
                 auto nSeeds = settings_.numberOfSeeds <=1.0 ? 
-                    size_t(float(graph.numberOfNodes())*settings_.numberOfSeeds+0.5f) :
-                    size_t(settings_.numberOfSeeds + 0.5);
+                    std::size_t(float(graph.numberOfNodes())*settings_.numberOfSeeds+0.5f) :
+                    std::size_t(settings_.numberOfSeeds + 0.5);
 
-                nSeeds = std::max(size_t(1),nSeeds);
-                nSeeds = std::min(size_t(negativeEdges_.size()-1), nSeeds);
+                nSeeds = std::max(std::size_t(1),nSeeds);
+                nSeeds = std::min(std::size_t(negativeEdges_.size()-1), nSeeds);
 
 
                 graph.forEachEdge([&](const uint64_t edge){
@@ -152,7 +152,7 @@ namespace lifted_multicut{
                 });
 
 
-                for(size_t i=0; i <  (nSeeds == 1 ? 1 : nSeeds/2); ++i){
+                for(std::size_t i=0; i <  (nSeeds == 1 ? 1 : nSeeds/2); ++i){
                     const auto randIndex = intDist_(gen);
                     const auto edge  = negativeEdges_[randIndex];
                     const auto uv = liftedGraph.uv(edge);
@@ -169,7 +169,7 @@ namespace lifted_multicut{
         }
     private:
         const ObjectiveType & objective_;
-        size_t numberOfThreads_;
+        std::size_t numberOfThreads_;
         SettingsType settings_;
         std::vector<uint64_t> negativeEdges_;
         EdgeWeights graphEdgeWeights_;

--- a/include/nifty/graph/opt/mincut/mincut_qpbo.hxx
+++ b/include/nifty/graph/opt/mincut/mincut_qpbo.hxx
@@ -73,7 +73,7 @@ namespace mincut{
         void repairSolution(NodeLabelsType & nodeLabels);
 
 
-        size_t addCycleInequalities();
+        std::size_t addCycleInequalities();
         void addThreeCyclesConstraintsExplicitly();
 
         const Objective & objective_;

--- a/include/nifty/graph/opt/mincut/proposal_generators/proposal_generator_base.hxx
+++ b/include/nifty/graph/opt/mincut/proposal_generators/proposal_generator_base.hxx
@@ -23,7 +23,7 @@ namespace mincut{
     
         virtual ~ProposalGeneratorBase(){}
 
-        virtual void generateProposal( const NodeLabels & currentBest,NodeLabels & labels, const size_t tid) = 0;
+        virtual void generateProposal( const NodeLabels & currentBest,NodeLabels & labels, const std::size_t tid) = 0;
 
     private:
     }; 

--- a/include/nifty/graph/opt/mincut/proposal_generators/proposal_generator_factory.hxx
+++ b/include/nifty/graph/opt/mincut/proposal_generators/proposal_generator_factory.hxx
@@ -28,10 +28,10 @@ namespace mincut{
 
         virtual ~ProposalGeneratorFactory(){}
 
-        virtual std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective,  const size_t numberOfThreads){
+        virtual std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective,  const std::size_t numberOfThreads){
             return std::make_shared<ProposalGeneratorType>(objective, numberOfThreads, settings_);
         }
-        virtual ProposalGeneratorBaseType *                create(   const ObjectiveType & objective,  const size_t numberOfThreads){
+        virtual ProposalGeneratorBaseType *                create(   const ObjectiveType & objective,  const std::size_t numberOfThreads){
             return new ProposalGeneratorType(objective, numberOfThreads, settings_);
         }
     private:

--- a/include/nifty/graph/opt/mincut/proposal_generators/proposal_generator_factory_base.hxx
+++ b/include/nifty/graph/opt/mincut/proposal_generators/proposal_generator_factory_base.hxx
@@ -20,8 +20,8 @@ namespace mincut{
         typedef ProposalGeneratorBase<ObjectiveType> ProposalGeneratorBaseType;
 
         virtual ~ProposalGeneratorFactoryBase(){}
-        virtual std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective, const size_t numberOfThreads) = 0;
-        virtual ProposalGeneratorBaseType *                create(   const ObjectiveType & objective, const size_t numberOfThreads) = 0;
+        virtual std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective, const std::size_t numberOfThreads) = 0;
+        virtual ProposalGeneratorBaseType *                create(   const ObjectiveType & objective, const std::size_t numberOfThreads) = 0;
     };
 
 

--- a/include/nifty/graph/opt/mincut/proposal_generators/random_proposal_generator.hxx
+++ b/include/nifty/graph/opt/mincut/proposal_generators/random_proposal_generator.hxx
@@ -44,7 +44,7 @@ namespace mincut{
 
         RandomProposalGenerator(
             const ObjectiveType & objective, 
-            const size_t numberOfThreads,
+            const std::size_t numberOfThreads,
             const SettingsType & settings  = SettingsType()
         )
         :   objective_(objective),
@@ -71,13 +71,13 @@ namespace mincut{
 
         virtual void generateProposal(
             const NodeLabels & currentBest,NodeLabels & proposal, 
-            const size_t tid
+            const std::size_t tid
         ){
             
         }
     private:
         const ObjectiveType & objective_;
-        size_t numberOfThreads_;
+        std::size_t numberOfThreads_;
         SettingsType settings_;
         std::vector<std::mt19937> gens_;    
     }; 

--- a/include/nifty/graph/opt/multicut/cgc.hxx
+++ b/include/nifty/graph/opt/multicut/cgc.hxx
@@ -906,8 +906,8 @@ namespace multicut{
         typedef std::pair<uint64_t, uint64_t> LabelPair;
         struct LabelPairHash{
         public:
-            size_t operator()(const std::pair<uint64_t, uint64_t> & x) const {
-                 size_t h = std::hash<uint64_t>()(x.first) ^ std::hash<uint64_t>()(x.second);
+            std::size_t operator()(const std::pair<uint64_t, uint64_t> & x) const {
+                 std::size_t h = std::hash<uint64_t>()(x.first) ^ std::hash<uint64_t>()(x.second);
                  return h;
             }
         };

--- a/include/nifty/graph/opt/multicut/chained_solvers.hxx
+++ b/include/nifty/graph/opt/multicut/chained_solvers.hxx
@@ -73,7 +73,7 @@ namespace multicut{
                     visitor_->addLogNames(logNames);
             }
 
-            virtual void setLogValue(const size_t logIndex, double logValue){
+            virtual void setLogValue(const std::size_t logIndex, double logValue){
                 if(visitor_ != nullptr)
                     visitor_->setLogValue(logIndex, logValue);
             }

--- a/include/nifty/graph/opt/multicut/fusion_move_based.hxx
+++ b/include/nifty/graph/opt/multicut/fusion_move_based.hxx
@@ -45,10 +45,10 @@ namespace multicut{
         struct SettingsType{
             int verbose { 1 };
             int numberOfThreads {-1};
-            size_t numberOfIterations {10};
-            size_t numberOfParallelProposals {4};
-            size_t fuseN{2};
-            size_t stopIfNoImprovement{4};
+            std::size_t numberOfIterations {10};
+            std::size_t numberOfParallelProposals {4};
+            std::size_t fuseN{2};
+            std::size_t stopIfNoImprovement{4};
             ProposalGenSettings proposalGenSettings;
             FusionMoveSettings fusionMoveSettings;
         };
@@ -69,7 +69,7 @@ namespace multicut{
         }
 
         virtual void weightsChanged(){
-            for(size_t i=0; i<pgens_.size(); ++i){
+            for(std::size_t i=0; i<pgens_.size(); ++i){
                 pgens_[i]->reset();
             }
         }
@@ -114,7 +114,7 @@ namespace multicut{
 
 
         nifty::parallel::parallel_foreach(threadPool_,nt,
-            [&](const size_t threadId, const size_t i){
+            [&](const std::size_t threadId, const std::size_t i){
                 NIFTY_CHECK_OP(threadId,<,fusionMoves_.size(),"");
                 pgens_[i] = new ProposalGen(objective_, settings_.proposalGenSettings, i);
                 fusionMoves_[i] = new FusionMoveType(objective_, settings_.fusionMoveSettings);
@@ -129,7 +129,7 @@ namespace multicut{
     FusionMoveBased<PROPPOSAL_GEN>::
     ~FusionMoveBased(){
 
-        for(size_t i=0; i<parallelOptions_.getActualNumThreads(); ++i){
+        for(std::size_t i=0; i<parallelOptions_.getActualNumThreads(); ++i){
             delete pgens_[i];
             delete fusionMoves_[i];
             delete solBufferIn_[i];
@@ -186,7 +186,7 @@ namespace multicut{
             //std::cout<<"generate "<<settings_.numberOfParallelProposals<<" proposals\n";
             nifty::parallel::parallel_foreach(threadPool_,
                 settings_.numberOfParallelProposals,
-                [&](const size_t threadId, int proposalIndex){
+                [&](const std::size_t threadId, int proposalIndex){
                     NIFTY_CHECK_OP(threadId,<,fusionMoves_.size(),"");
                     // 
                     auto & pgen = *pgens_[threadId];
@@ -239,7 +239,7 @@ namespace multicut{
             //std::cout<<"Generated "<<proposals.size() << " in parallel." << "\n";
             // recursive thing
             std::vector<NodeLabelsType> proposals2;
-            size_t nFuse = settings_.fuseN;
+            std::size_t nFuse = settings_.fuseN;
 
             if(!proposals.empty() && nFuse > 0){
                 while(proposals.size()!= 1){
@@ -259,7 +259,7 @@ namespace multicut{
                         auto i = ii*nFuse;
 
                         std::vector<const NodeLabelsType*> toFuse;
-                        for(size_t j=0; j<nFuse; ++j){
+                        for(std::size_t j=0; j<nFuse; ++j){
                             auto k = i + j < proposals.size() ? i+j : i+j - proposals.size();
                             toFuse.push_back(&proposals[k]);
                         }

--- a/include/nifty/graph/opt/multicut/multicut_andres.hxx
+++ b/include/nifty/graph/opt/multicut/multicut_andres.hxx
@@ -145,8 +145,8 @@ namespace multicut{
         typedef andres::graph::multicut::KernighanLinSettings KlSettings;
 
         struct SettingsType {
-            size_t numberOfInnerIterations { std::numeric_limits<size_t>::max() };
-            size_t numberOfOuterIterations { 100 };
+            std::size_t numberOfInnerIterations { std::numeric_limits<std::size_t>::max() };
+            std::size_t numberOfOuterIterations { 100 };
             double epsilon { 1e-6 };
             bool verbose { false };
             bool greedyWarmstart{true};

--- a/include/nifty/graph/opt/multicut/multicut_decomposer.hxx
+++ b/include/nifty/graph/opt/multicut/multicut_decomposer.hxx
@@ -76,9 +76,9 @@ namespace multicut{
             SubgraphWithCut(const WeightsMap & weights)
                 :   weights_(weights)
             {}
-            bool useNode(const size_t v) const
+            bool useNode(const std::size_t v) const
                 { return true; }
-            bool useEdge(const size_t e) const
+            bool useEdge(const std::size_t e) const
             {
                 return weights_[e] > 0.0;
             }
@@ -138,7 +138,7 @@ namespace multicut{
         // build the connected components
         NodeLabelsType denseLabels(graph_);
         const auto nComponents = components_.build(SubgraphWithCut(weights_));
-        std::vector<size_t> componentsSize(nComponents,0);
+        std::vector<std::size_t> componentsSize(nComponents,0);
         components_.denseRelabeling(denseLabels, componentsSize);
 
 
@@ -161,7 +161,7 @@ namespace multicut{
             // - allocate the sub graphs
             // - sparse to dense
             std::vector<SubmodelGraph *> subGraphVec(nComponents);
-            for(size_t i=0; i<nComponents; ++i){
+            for(std::size_t i=0; i<nComponents; ++i){
                 NIFTY_CHECK_OP(componentsSize[i],>,0,"");
                 if(componentsSize[i]>1)
                     subGraphVec[i] = new SubmodelGraph(componentsSize[i]);
@@ -215,7 +215,7 @@ namespace multicut{
             //visitorProxy.printLog(nifty::logging::LogLevel::INFO, "build sub-objectives");
             // build the sub mc objectives
             std::vector<SubmodelObjective *> subObjectiveVec(nComponents);
-            for(size_t i=0; i<nComponents; ++i){
+            for(std::size_t i=0; i<nComponents; ++i){
                 if(componentsSize[i]>1)
                     subObjectiveVec[i] = new SubmodelObjective(*subGraphVec[i]);
             }
@@ -243,7 +243,7 @@ namespace multicut{
             // //////////////////////////////////////////////
             // solving and partial cleanup
             // //////////////////////////////////////////////
-            for(size_t i=0; i<nComponents; ++i){
+            for(std::size_t i=0; i<nComponents; ++i){
                 if(componentsSize[i]>1){
                     const auto & subObj = *subObjectiveVec[i];
                     const auto & subGraph = *subGraphVec[i];
@@ -292,7 +292,7 @@ namespace multicut{
 
             //visitorProxy.printLog(nifty::logging::LogLevel::INFO, "cleanup");
             // final cleanup
-            for(size_t i=0; i<nComponents; ++i){
+            for(std::size_t i=0; i<nComponents; ++i){
                 if(componentsSize[i]>1){
                     delete subNodeLabelsVec[i];
                 }

--- a/include/nifty/graph/opt/multicut/multicut_ilp.hxx
+++ b/include/nifty/graph/opt/multicut/multicut_ilp.hxx
@@ -124,9 +124,9 @@ namespace multicut{
                 :   ilpSolver_(ilpSolver),
                     denseIds_(denseIds)
             {}
-            bool useNode(const size_t v) const
+            bool useNode(const std::size_t v) const
                 { return true; }
-            bool useEdge(const size_t e) const
+            bool useEdge(const std::size_t e) const
                 { return ilpSolver_.label(denseIds_[e]) == 0; }
 
             const IlpSovler & ilpSolver_;
@@ -151,7 +151,7 @@ namespace multicut{
              *  A value of zero will be interpreted as an unlimited
              *  number of iterations.
              */
-            size_t numberOfIterations{0};   
+            std::size_t numberOfIterations{0};   
 
             /**
              *  \brief Explicitly add constrains for cycle of length three.
@@ -224,7 +224,7 @@ namespace multicut{
         void repairSolution(NodeLabelsType & nodeLabels);
 
 
-        size_t addCycleInequalities();
+        std::size_t addCycleInequalities();
         void addThreeCyclesConstraintsExplicitly();
 
         const ObjectiveType & objective_;
@@ -238,11 +238,11 @@ namespace multicut{
         DenseIds denseIds_;
         BidirectionalBreadthFirstSearch<Graph> bibfs_;
         SettingsType settings_;
-        std::vector<size_t> variables_;
+        std::vector<std::size_t> variables_;
         std::vector<double> coefficients_;
         NodeLabelsType * currentBest_;
-        size_t addedConstraints_;
-        size_t numberOfOptRuns_;
+        std::size_t addedConstraints_;
+        std::size_t numberOfOptRuns_;
     };
 
     
@@ -291,7 +291,7 @@ namespace multicut{
             auto edgeLabelIter = detail_graph::nodeLabelsToEdgeLabelsIterBegin(graph_, nodeLabels);
             ilpSolver_->setStart(edgeLabelIter);
 
-            for (size_t i = 0; settings_.numberOfIterations == 0 || i < settings_.numberOfIterations; ++i){
+            for (std::size_t i = 0; settings_.numberOfIterations == 0 || i < settings_.numberOfIterations; ++i){
 
                 // solve ilp
                 ilpSolver_->optimize();
@@ -326,14 +326,14 @@ namespace multicut{
     }
 
     template<class OBJECTIVE, class ILP_SOLVER>
-    size_t MulticutIlp<OBJECTIVE, ILP_SOLVER>::
+    std::size_t MulticutIlp<OBJECTIVE, ILP_SOLVER>::
     addCycleInequalities(
     ){
 
         components_.build(SubgraphWithCut(*ilpSolver_, denseIds_));
 
         // search for violated non-chordal cycles and add corresp. inequalities
-        size_t nCycle = 0;
+        std::size_t nCycle = 0;
 
 
         // we iterate over edges and the corresponding lpEdge 
@@ -360,7 +360,7 @@ namespace multicut{
                         continue;
                     }
 
-                    for (size_t j = 0; j < sz - 1; ++j){
+                    for (std::size_t j = 0; j < sz - 1; ++j){
                         variables_[j] = denseIds_[graph_.findEdge(path[j], path[j + 1])];
                         coefficients_[j] = 1.0;
                     }
@@ -422,7 +422,7 @@ namespace multicut{
     addThreeCyclesConstraintsExplicitly(
     ){
         //std::cout<<"add three cyckes\n";
-        std::array<size_t, 3> variables;
+        std::array<std::size_t, 3> variables;
         std::array<double, 3> coefficients;
         auto threeCycles = findThreeCyclesEdges(graph_);
         auto c = 0;

--- a/include/nifty/graph/opt/multicut/multicut_mp.hxx
+++ b/include/nifty/graph/opt/multicut/multicut_mp.hxx
@@ -100,21 +100,21 @@ namespace multicut{
             // multicut factory for the primal rounder used in lp_mp
             std::shared_ptr<McFactoryBase> mcFactory;
             // settings for the lp_mp solver
-            size_t numberOfIterations{1000};
+            std::size_t numberOfIterations{1000};
             int verbose{0};
-            size_t primalComputationInterval{100};
+            std::size_t primalComputationInterval{100};
             std::string standardReparametrization{"anisotropic"};
             std::string roundingReparametrization{"damped_uniform"};
             std::string tightenReparametrization{"damped_uniform"};
             bool tighten{true};
-            size_t tightenInterval{100};
-            size_t tightenIteration{10};
+            std::size_t tightenInterval{100};
+            std::size_t tightenIteration{10};
             double tightenSlope{0.02};
             double tightenConstraintsPercentage{0.1};
             double minDualImprovement{0.};
-            size_t minDualImprovementInterval{0};
-            size_t timeout{0};
-            size_t numberOfThreads{1};
+            std::size_t minDualImprovementInterval{0};
+            std::size_t timeout{0};
+            std::size_t numberOfThreads{1};
         };
 
         virtual ~MulticutMp(){
@@ -148,7 +148,7 @@ namespace multicut{
 
         SettingsType settings_;
         NodeLabelsType * currentBest_;
-        size_t numberOfOptRuns_;
+        std::size_t numberOfOptRuns_;
         SolverType * mpSolver_;
         ufd::Ufd<uint64_t> ufd_;
     };

--- a/include/nifty/graph/opt/multicut/perturb_and_map.hxx
+++ b/include/nifty/graph/opt/multicut/perturb_and_map.hxx
@@ -40,7 +40,7 @@ namespace multicut{
 
         struct SettingsType{
             FactorySmartPtr mcFactory;
-            size_t numberOfIterations{100};
+            std::size_t numberOfIterations{100};
             int numberOfThreads{-1};
             int verbose = 2;
             int seed = 42;
@@ -63,7 +63,7 @@ namespace multicut{
     private:
 
         struct ThreadData{
-            ThreadData(const size_t threadId,const int seed, const Graph & graph)
+            ThreadData(const std::size_t threadId,const int seed, const Graph & graph)
             :   objective_(graph),
                 solver_(nullptr),
                 gen_(threadId+seed),
@@ -81,7 +81,7 @@ namespace multicut{
 
 
         template<class WEIGHTS>
-        void perturbWeights(const size_t threadId, WEIGHTS & perturbedWeights);
+        void perturbWeights(const std::size_t threadId, WEIGHTS & perturbedWeights);
 
 
 
@@ -117,7 +117,7 @@ namespace multicut{
 
         nifty::parallel::parallel_foreach(settings_.numberOfThreads,
             popt.getActualNumThreads(),
-            [&](size_t threadId, int tid){
+            [&](std::size_t threadId, int tid){
                 auto & threadDataPtr = threadDataVec_[tid];
                 threadDataPtr = new ThreadData(tid, settings_.seed, graph_);
                 // copy weights
@@ -135,7 +135,7 @@ namespace multicut{
     template<class OBJECTIVE>
     PerturbAndMap<OBJECTIVE>::
     ~PerturbAndMap(){
-        for(size_t i=0; i<threadDataVec_.size(); ++i){
+        for(std::size_t i=0; i<threadDataVec_.size(); ++i){
             delete threadDataVec_[i]->solver_;
             delete threadDataVec_[i];
         }
@@ -180,7 +180,7 @@ namespace multicut{
 
         nifty::parallel::parallel_foreach(settings_.numberOfThreads,
             settings_.numberOfIterations,
-            [&](size_t threadId, int items){
+            [&](std::size_t threadId, int items){
                 auto & threadData = *threadDataVec_[threadId];
                 auto & obj = threadData.objective_;
                 auto solver = threadData.solver_;
@@ -224,7 +224,7 @@ namespace multicut{
     template<class WEIGHTS>
     void PerturbAndMap<OBJECTIVE>::
     perturbWeights( 
-        const size_t threadId,
+        const std::size_t threadId,
         WEIGHTS & perturbedWeights
     ){
 

--- a/include/nifty/graph/opt/multicut/proposal_generators/greedy_additive_proposals.hxx
+++ b/include/nifty/graph/opt/multicut/proposal_generators/greedy_additive_proposals.hxx
@@ -36,7 +36,7 @@ namespace multicut{
         GreedyAdditiveProposals(
             const Objective & objective, 
             const SettingsType  & settings,
-            const size_t threadIndex
+            const std::size_t threadIndex
         )
         :   objective_(objective),
             graph_(objective.graph()),
@@ -84,8 +84,8 @@ namespace multicut{
         const Objective & objective_;
         const Graph graph_;
         SettingsType settings_;
-        size_t threadIndex_;
-        size_t proposalNumber_;
+        std::size_t threadIndex_;
+        std::size_t proposalNumber_;
 
         Solver * solver_;
 

--- a/include/nifty/graph/opt/multicut/proposal_generators/watershed_proposals.hxx
+++ b/include/nifty/graph/opt/multicut/proposal_generators/watershed_proposals.hxx
@@ -36,7 +36,7 @@ namespace multicut{
         WatershedProposals(
             const Objective & objective, 
             const SettingsType  & settings,
-            const size_t threadIndex
+            const std::size_t threadIndex
         )
         :   objective_(objective),
             graph_(objective.graph()),
@@ -62,12 +62,12 @@ namespace multicut{
                 proposal = currentBest;
             }
             else{
-                size_t nSeeds = settings_.seedFraction <=1.0 ? 
-                    size_t(float(graph_.numberOfNodes())*settings_.seedFraction+0.5f) :
-                    size_t(settings_.seedFraction + 0.5);
+                std::size_t nSeeds = settings_.seedFraction <=1.0 ? 
+                    std::size_t(float(graph_.numberOfNodes())*settings_.seedFraction+0.5f) :
+                    std::size_t(settings_.seedFraction + 0.5);
 
-                nSeeds = std::max(size_t(1),nSeeds);
-                nSeeds = std::min(size_t(negativeEdges_.size()-1), nSeeds);
+                nSeeds = std::max(std::size_t(1),nSeeds);
+                nSeeds = std::min(std::size_t(negativeEdges_.size()-1), nSeeds);
 
 
                 // get the seeds
@@ -75,7 +75,7 @@ namespace multicut{
                     seeds_[node] = 0;
 
 
-                for(size_t i=0; i <  (nSeeds == 1 ? 1 : nSeeds/2); ++i){
+                for(std::size_t i=0; i <  (nSeeds == 1 ? 1 : nSeeds/2); ++i){
                     const auto randIndex = intDist_(gen_);
                     const auto edge  = negativeEdges_[randIndex];
 
@@ -121,8 +121,8 @@ namespace multicut{
         NodeLabelsType seeds_;
         std::vector<uint64_t> negativeEdges_;
         SettingsType settings_;
-        size_t threadIndex_;
-        size_t proposalNumber_;
+        std::size_t threadIndex_;
+        std::size_t proposalNumber_;
         std::mt19937 gen_;
         std::normal_distribution<> dist_;
         std::uniform_int_distribution<>  intDist_;

--- a/include/nifty/graph/paths.hxx
+++ b/include/nifty/graph/paths.hxx
@@ -68,7 +68,7 @@ findChord(
 
 
 template<class PREDECESSORS_MAP, class OUT_ITER>
-size_t buildPathInLargeEnoughBuffer(
+std::size_t buildPathInLargeEnoughBuffer(
     const uint64_t source,
     const uint64_t target,
     const PREDECESSORS_MAP & predecessorMap,

--- a/include/nifty/graph/rag/detail_rag/compute_grid_rag.hxx
+++ b/include/nifty/graph/rag/detail_rag/compute_grid_rag.hxx
@@ -131,7 +131,7 @@ struct ComputeRag< GridRagStacked2D< LABELS_PROXY > > {
 
         typedef array::StaticArray<int64_t, 3> Coord;
         typedef array::StaticArray<int64_t, 2> Coord2;
-        typedef std::map<EdgeStorage, size_t> EdgeLengthsType;
+        typedef std::map<EdgeStorage, std::size_t> EdgeLengthsType;
         typedef std::vector<EdgeLengthsType> EdgeLenghtsStorage;
 
         const auto & labelsProxy = rag.labelsProxy();

--- a/include/nifty/graph/rag/detail_rag/compute_grid_rag.hxx
+++ b/include/nifty/graph/rag/detail_rag/compute_grid_rag.hxx
@@ -146,7 +146,7 @@ struct ComputeRag< GridRagStacked2D< LABELS_PROXY > > {
 
         uint64_t numberOfSlices = shape[0];
         Coord2 sliceShape2({shape[1], shape[2]});
-        Coord sliceShape3({1L, shape[1], shape[2]});
+        Coord sliceShape3({1LL, shape[1], shape[2]});
 
         auto & perSliceDataVec = rag.perSliceDataVec_;
 
@@ -170,7 +170,7 @@ struct ComputeRag< GridRagStacked2D< LABELS_PROXY > > {
                 auto sliceLabelsFlat3DView = sliceLabelsStorage.getView(tid);
 
                 // fetch the data for the slice
-                const Coord blockBegin({sliceIndex,0L,0L});
+                const Coord blockBegin({sliceIndex,0LL,0LL});
                 const Coord blockEnd({sliceIndex+1, sliceShape2[0], sliceShape2[1]});
                 labelsProxy.readSubarray(blockBegin, blockEnd, sliceLabelsFlat3DView);
                 auto sliceLabels = sliceLabelsFlat3DView.squeezedView();
@@ -291,8 +291,8 @@ struct ComputeRag< GridRagStacked2D< LABELS_PROXY > > {
                         auto & edgeLens = edgeLenStorage[sliceAIndex];
 
                         // fetch the data for the slice
-                        const Coord beginA({sliceAIndex,0L,0L});
-                        const Coord beginB({sliceBIndex,0L,0L});
+                        const Coord beginA({sliceAIndex,0LL,0LL});
+                        const Coord beginB({sliceBIndex,0LL,0LL});
                         const Coord endA({sliceAIndex+1,shape[1],shape[2]});
                         const Coord endB({sliceBIndex+1,shape[1],shape[2]});
                         

--- a/include/nifty/graph/rag/detail_rag/compute_grid_rag.hxx
+++ b/include/nifty/graph/rag/detail_rag/compute_grid_rag.hxx
@@ -146,7 +146,7 @@ struct ComputeRag< GridRagStacked2D< LABELS_PROXY > > {
 
         uint64_t numberOfSlices = shape[0];
         Coord2 sliceShape2({shape[1], shape[2]});
-        Coord sliceShape3({1LL, shape[1], shape[2]});
+        Coord sliceShape3({int64_t(1), shape[1], shape[2]});
 
         auto & perSliceDataVec = rag.perSliceDataVec_;
 
@@ -170,7 +170,7 @@ struct ComputeRag< GridRagStacked2D< LABELS_PROXY > > {
                 auto sliceLabelsFlat3DView = sliceLabelsStorage.getView(tid);
 
                 // fetch the data for the slice
-                const Coord blockBegin({sliceIndex,0LL,0LL});
+                const Coord blockBegin({sliceIndex,int64_t(0),int64_t(0)});
                 const Coord blockEnd({sliceIndex+1, sliceShape2[0], sliceShape2[1]});
                 labelsProxy.readSubarray(blockBegin, blockEnd, sliceLabelsFlat3DView);
                 auto sliceLabels = sliceLabelsFlat3DView.squeezedView();
@@ -291,8 +291,8 @@ struct ComputeRag< GridRagStacked2D< LABELS_PROXY > > {
                         auto & edgeLens = edgeLenStorage[sliceAIndex];
 
                         // fetch the data for the slice
-                        const Coord beginA({sliceAIndex,0LL,0LL});
-                        const Coord beginB({sliceBIndex,0LL,0LL});
+                        const Coord beginA({sliceAIndex,int64_t(0),int64_t(0)});
+                        const Coord beginB({sliceBIndex,int64_t(0),int64_t(0)});
                         const Coord endA({sliceAIndex+1,shape[1],shape[2]});
                         const Coord endB({sliceBIndex+1,shape[1],shape[2]});
                         

--- a/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_filters_stacked.hxx
+++ b/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_filters_stacked.hxx
@@ -259,7 +259,7 @@ void accumulateEdgeFeaturesFromFiltersWithAccChain(
     uint64_t numberOfSlices = shape[0];
 
     Coord2 sliceShape2({shape[1], shape[2]});
-    Coord sliceShape3({1LL, shape[1], shape[2]});
+    Coord sliceShape3({int64_t(1), shape[1], shape[2]});
     Coord filterShape({int64_t(numberOfChannels), shape[1], shape[2]});
 
     // filter computation and accumulation
@@ -281,8 +281,8 @@ void accumulateEdgeFeaturesFromFiltersWithAccChain(
         //FilterBlockStorage dataCopyStorage(threadpool, sliceShape2, actualNumberOfThreads);
 
         // process slice 0 to find min and max for histogram opts
-        Coord begin0({0LL, 0LL, 0LL});
-        Coord end0(  {1LL, shape[1], shape[2]});
+        Coord begin0({int64_t(0), int64_t(0), int64_t(0)});
+        Coord end0(  {int64_t(1), shape[1], shape[2]});
 
         auto data0 = dataStorage.getView(0);
         tools::readSubarray(data, begin0, end0, data0);
@@ -312,10 +312,10 @@ void accumulateEdgeFeaturesFromFiltersWithAccChain(
         //        true);
 
         std::vector<vigra::HistogramOptions> histoOptionsVec(numberOfChannels);
-        Coord cShape({1LL,sliceShape2[0],sliceShape2[1]});
+        Coord cShape({int64_t(1),sliceShape2[0],sliceShape2[1]});
         parallel::parallel_foreach(threadpool, numberOfChannels, [&](const int tid, const int64_t c){
             auto & histoOpts = histoOptionsVec[c];
-            Coord cBegin({c,0LL,0LL});
+            Coord cBegin({c,int64_t(0),int64_t(0)});
             auto channelView = filter0.view(cBegin.begin(), cShape.begin());
             auto minMax = std::minmax_element(channelView.begin(), channelView.end());
             auto min = *(minMax.first);
@@ -340,7 +340,7 @@ void accumulateEdgeFeaturesFromFiltersWithAccChain(
             int64_t sliceIdB = slicePairs[pairId].second;// upper slice
 
             // compute the filters for slice A
-            Coord beginA ({sliceIdA, 0LL, 0LL});
+            Coord beginA ({sliceIdA, int64_t(0), int64_t(0)});
             Coord endA({sliceIdA+1, shape[1], shape[2]});
 
             auto labelsA = labelsAStorage.getView(tid);
@@ -386,7 +386,7 @@ void accumulateEdgeFeaturesFromFiltersWithAccChain(
             }
 
             // process upper slice
-            Coord beginB = Coord({sliceIdB,   0LL,       0LL});
+            Coord beginB = Coord({sliceIdB,   int64_t(0),       int64_t(0)});
             Coord endB   = Coord({sliceIdB+1, shape[1], shape[2]});
             auto filterB = filterBStorage.getView(tid);
             marray::View<LabelType> labelsBSqueezed;
@@ -523,7 +523,7 @@ void accumulateEdgeFeaturesFromFilters(
             }
         }
 
-        FeatCoord begin({int64_t(edgeOffset),0LL});
+        FeatCoord begin({int64_t(edgeOffset),int64_t(0)});
         FeatCoord end({edgeOffset+nEdges,uint64_t(nChannels*nStats)});
 
         tools::writeSubarray(edgeFeaturesOut, begin, end, featuresTemp);
@@ -601,7 +601,7 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
     std::size_t numberOfChannels = applyFilters.numberOfChannels();
 
     Coord2 sliceShape2({shape[1], shape[2]});
-    Coord sliceShape3({1LL,shape[1], shape[2]});
+    Coord sliceShape3({int64_t(1),shape[1], shape[2]});
     Coord filterShape({int64_t(numberOfChannels), shape[1], shape[2]});
 
     // filter computation and accumulation
@@ -663,7 +663,7 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
             std::cout << countSlice++ << " / " << lowerSlices.size() << std::endl;
             std::cout << "Finding features for skip edges from slice " << sliceId << std::endl;
 
-            Coord beginA({int64_t(sliceId),0LL,0LL});
+            Coord beginA({int64_t(sliceId),int64_t(0),int64_t(0)});
             Coord endA(  {int64_t(sliceId+1),shape[1],shape[2]});
             auto labelsA = labelsAStorage.getView(0);
             labelsProxy.readSubarray(beginA, endA, labelsA);
@@ -686,11 +686,11 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
 
             // set the correct histogram for each filter from lowest slice
             if(sliceId == lowest){
-                Coord cShape({1LL,sliceShape2[0],sliceShape2[1]});
+                Coord cShape({int64_t(1),sliceShape2[0],sliceShape2[1]});
                 parallel::parallel_foreach(threadpool, numberOfChannels, [&](const int tid, const int64_t c){
                     auto & histoOpts = histoOptionsVec[c];
 
-                    Coord cBegin({c,0LL,0LL});
+                    Coord cBegin({c,int64_t(0),int64_t(0)});
                     auto channelView = filterA.view(cBegin.begin(), cShape.begin());
                     auto minMax = std::minmax_element(channelView.begin(), channelView.end());
                     auto min = *(minMax.first);
@@ -723,7 +723,7 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
             for(auto nextId : skipSlices[sliceId] ) {
                 std::cout << "to slice " << nextId << std::endl;
 
-                beginB = Coord({int64_t(nextId),0LL,0LL});
+                beginB = Coord({int64_t(nextId),int64_t(0),int64_t(0)});
                 endB   = Coord({int64_t(nextId+1),shape[1],shape[2]});
 
                 auto labelsB = labelsBStorage.getView(0);
@@ -892,7 +892,7 @@ void accumulateSkipEdgeFeaturesFromFilters(
                 }
             });
 
-            FeatCoord begin({int64_t(edgeOffset),0LL});
+            FeatCoord begin({int64_t(edgeOffset),int64_t(0)});
             FeatCoord end({edgeOffset+nEdges,uint64_t(nChannels*nStats)});
 
             tools::writeSubarray(edgeFeaturesOut, begin, end, featuresTemp);

--- a/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_filters_stacked.hxx
+++ b/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_filters_stacked.hxx
@@ -106,8 +106,8 @@ inline void accumulateInnerSliceFeatures(ACC_CHAIN_VECTOR & channelAccChainVec,
     typedef typename vigra::MultiArrayShape<3>::type VigraCoord;
     typedef LABEL_TYPE LabelType;
 
-    size_t pass = 1;
-    size_t numberOfChannels = channelAccChainVec[0].size();
+    std::size_t pass = 1;
+    std::size_t numberOfChannels = channelAccChainVec[0].size();
 
     // set minmax for accumulator chains
     for(int64_t edge = 0; edge < channelAccChainVec.size(); ++edge){
@@ -166,8 +166,8 @@ inline void accumulateBetweenSliceFeatures(ACC_CHAIN_VECTOR & channelAccChainVec
     typedef typename vigra::MultiArrayShape<3>::type VigraCoord;
     typedef LABEL_TYPE LabelType;
 
-    size_t pass = 1;
-    size_t numberOfChannels = channelAccChainVec[0].size();
+    std::size_t pass = 1;
+    std::size_t numberOfChannels = channelAccChainVec[0].size();
 
     // set minmax for accumulator chains
     for(int64_t edge = 0; edge < channelAccChainVec.size(); ++edge){
@@ -241,7 +241,7 @@ void accumulateEdgeFeaturesFromFiltersWithAccChain(
     typedef std::vector<AccChainVectorType> ChannelAccChainVectorType;
     typedef typename features::ApplyFilters<2>::FiltersToSigmasType FiltersToSigmasType;
 
-    const size_t actualNumberOfThreads = pOpts.getActualNumThreads();
+    const std::size_t actualNumberOfThreads = pOpts.getActualNumThreads();
 
     const auto & shape = rag.shape();
     const auto & labelsProxy = rag.labelsProxy();
@@ -254,7 +254,7 @@ void accumulateEdgeFeaturesFromFiltersWithAccChain(
                                           { true, true, true } });  // HessianOfGaussianEigenvalues
 
     features::ApplyFilters<2> applyFilters(sigmas, filtersToSigmas);
-    size_t numberOfChannels = applyFilters.numberOfChannels();
+    std::size_t numberOfChannels = applyFilters.numberOfChannels();
 
     uint64_t numberOfSlices = shape[0];
 
@@ -559,8 +559,8 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
     const GridRagStacked2D<LABELS_PROXY> & rag,
     const DATA & data,
     const std::vector<std::pair<uint64_t,uint64_t>> & skipEdges,
-    const std::vector<size_t> & skipRanges,
-    const std::vector<size_t> & skipStarts,
+    const std::vector<std::size_t> & skipRanges,
+    const std::vector<std::size_t> & skipStarts,
     const parallel::ParallelOptions & pOpts,
     parallel::ThreadPool & threadpool,
     F && f,
@@ -585,7 +585,7 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
 
     typedef typename features::ApplyFilters<2>::FiltersToSigmasType FiltersToSigmasType;
 
-    const size_t actualNumberOfThreads = pOpts.getActualNumThreads();
+    const std::size_t actualNumberOfThreads = pOpts.getActualNumThreads();
 
     const auto & shape = rag.shape();
     const auto & labelsProxy = rag.labelsProxy();
@@ -598,7 +598,7 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
                                           { true, true, true } });  // HessianOfGaussianEigenvalues
 
     features::ApplyFilters<2> applyFilters(sigmas, filtersToSigmas);
-    size_t numberOfChannels = applyFilters.numberOfChannels();
+    std::size_t numberOfChannels = applyFilters.numberOfChannels();
 
     Coord2 sliceShape2({shape[1], shape[2]});
     Coord sliceShape3({1LL,shape[1], shape[2]});
@@ -619,26 +619,26 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
         FilterBlockStorage dataCopyStorage(threadpool, sliceShape2, 1);
 
         // get unique lower slices with skip edges
-        std::vector<size_t> lowerSlices;
+        std::vector<std::size_t> lowerSlices;
         tools::uniques(skipStarts, lowerSlices);
         auto lowest = int64_t(lowerSlices[0]);
 
         // get upper slices with skip edges for each lower slice and number of skip edges for each lower slice
-        std::map<size_t,std::vector<size_t>> skipSlices;
-        std::map<size_t,size_t> numberOfSkipEdgesPerSlice;
+        std::map<std::size_t,std::vector<std::size_t>> skipSlices;
+        std::map<std::size_t,size_t> numberOfSkipEdgesPerSlice;
 
         // initialize the maps
         std::cout << "Lower slices with skip edges:" << std::endl;
         for(auto sliceId : lowerSlices) {
             std::cout << sliceId << std::endl;
-            skipSlices[sliceId] = std::vector<size_t>();
+            skipSlices[sliceId] = std::vector<std::size_t>();
             numberOfSkipEdgesPerSlice[sliceId] = 0;
         }
 
         // determine the number of skip edges starting from each slice
         // and fill the conversion of uv-ids to edge-id
-        std::map<SkipEdgeStorage, size_t> skipUvsToIds;
-        for(size_t skipId = 0; skipId < skipEdges.size(); ++skipId) {
+        std::map<SkipEdgeStorage, std::size_t> skipUvsToIds;
+        for(std::size_t skipId = 0; skipId < skipEdges.size(); ++skipId) {
 
             // find the source slice of this skip edge and increment the number of edges in the slice
             auto sliceId = skipStarts[skipId];
@@ -656,7 +656,7 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
 
         std::vector<vigra::HistogramOptions> histoOptionsVec(numberOfChannels);
 
-        size_t skipEdgeOffset = 0;
+        std::size_t skipEdgeOffset = 0;
         int countSlice = 0;
         for(auto sliceId : lowerSlices) {
 
@@ -829,8 +829,8 @@ void accumulateSkipEdgeFeaturesFromFilters(
     const DATA & data,
     OUTPUT & edgeFeaturesOut,
     const std::vector<std::pair<uint64_t,uint64_t>> & skipEdges,
-    const std::vector<size_t> & skipRanges,
-    const std::vector<size_t> & skipStarts,
+    const std::vector<std::size_t> & skipRanges,
+    const std::vector<std::size_t> & skipStarts,
     const int zDirection = 0,
     const int numberOfThreads = -1
 ){

--- a/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_filters_stacked.hxx
+++ b/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_filters_stacked.hxx
@@ -259,7 +259,7 @@ void accumulateEdgeFeaturesFromFiltersWithAccChain(
     uint64_t numberOfSlices = shape[0];
 
     Coord2 sliceShape2({shape[1], shape[2]});
-    Coord sliceShape3({1L, shape[1], shape[2]});
+    Coord sliceShape3({1LL, shape[1], shape[2]});
     Coord filterShape({int64_t(numberOfChannels), shape[1], shape[2]});
 
     // filter computation and accumulation
@@ -281,8 +281,8 @@ void accumulateEdgeFeaturesFromFiltersWithAccChain(
         //FilterBlockStorage dataCopyStorage(threadpool, sliceShape2, actualNumberOfThreads);
 
         // process slice 0 to find min and max for histogram opts
-        Coord begin0({0L, 0L, 0L});
-        Coord end0(  {1L, shape[1], shape[2]});
+        Coord begin0({0LL, 0LL, 0LL});
+        Coord end0(  {1LL, shape[1], shape[2]});
 
         auto data0 = dataStorage.getView(0);
         tools::readSubarray(data, begin0, end0, data0);
@@ -312,10 +312,10 @@ void accumulateEdgeFeaturesFromFiltersWithAccChain(
         //        true);
 
         std::vector<vigra::HistogramOptions> histoOptionsVec(numberOfChannels);
-        Coord cShape({1L,sliceShape2[0],sliceShape2[1]});
+        Coord cShape({1LL,sliceShape2[0],sliceShape2[1]});
         parallel::parallel_foreach(threadpool, numberOfChannels, [&](const int tid, const int64_t c){
             auto & histoOpts = histoOptionsVec[c];
-            Coord cBegin({c,0L,0L});
+            Coord cBegin({c,0LL,0LL});
             auto channelView = filter0.view(cBegin.begin(), cShape.begin());
             auto minMax = std::minmax_element(channelView.begin(), channelView.end());
             auto min = *(minMax.first);
@@ -340,7 +340,7 @@ void accumulateEdgeFeaturesFromFiltersWithAccChain(
             int64_t sliceIdB = slicePairs[pairId].second;// upper slice
 
             // compute the filters for slice A
-            Coord beginA ({sliceIdA, 0L, 0L});
+            Coord beginA ({sliceIdA, 0LL, 0LL});
             Coord endA({sliceIdA+1, shape[1], shape[2]});
 
             auto labelsA = labelsAStorage.getView(tid);
@@ -386,7 +386,7 @@ void accumulateEdgeFeaturesFromFiltersWithAccChain(
             }
 
             // process upper slice
-            Coord beginB = Coord({sliceIdB,   0L,       0L});
+            Coord beginB = Coord({sliceIdB,   0LL,       0LL});
             Coord endB   = Coord({sliceIdB+1, shape[1], shape[2]});
             auto filterB = filterBStorage.getView(tid);
             marray::View<LabelType> labelsBSqueezed;
@@ -523,8 +523,8 @@ void accumulateEdgeFeaturesFromFilters(
             }
         }
 
-        FeatCoord begin({int64_t(edgeOffset),0L});
-        FeatCoord end({edgeOffset+nEdges,nChannels*nStats});
+        FeatCoord begin({int64_t(edgeOffset),0LL});
+        FeatCoord end({edgeOffset+nEdges,uint64_t(nChannels*nStats)});
 
         tools::writeSubarray(edgeFeaturesOut, begin, end, featuresTemp);
     };
@@ -601,7 +601,7 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
     size_t numberOfChannels = applyFilters.numberOfChannels();
 
     Coord2 sliceShape2({shape[1], shape[2]});
-    Coord sliceShape3({1L,shape[1], shape[2]});
+    Coord sliceShape3({1LL,shape[1], shape[2]});
     Coord filterShape({int64_t(numberOfChannels), shape[1], shape[2]});
 
     // filter computation and accumulation
@@ -663,7 +663,7 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
             std::cout << countSlice++ << " / " << lowerSlices.size() << std::endl;
             std::cout << "Finding features for skip edges from slice " << sliceId << std::endl;
 
-            Coord beginA({int64_t(sliceId),0L,0L});
+            Coord beginA({int64_t(sliceId),0LL,0LL});
             Coord endA(  {int64_t(sliceId+1),shape[1],shape[2]});
             auto labelsA = labelsAStorage.getView(0);
             labelsProxy.readSubarray(beginA, endA, labelsA);
@@ -686,11 +686,11 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
 
             // set the correct histogram for each filter from lowest slice
             if(sliceId == lowest){
-                Coord cShape({1L,sliceShape2[0],sliceShape2[1]});
+                Coord cShape({1LL,sliceShape2[0],sliceShape2[1]});
                 parallel::parallel_foreach(threadpool, numberOfChannels, [&](const int tid, const int64_t c){
                     auto & histoOpts = histoOptionsVec[c];
 
-                    Coord cBegin({c,0L,0L});
+                    Coord cBegin({c,0LL,0LL});
                     auto channelView = filterA.view(cBegin.begin(), cShape.begin());
                     auto minMax = std::minmax_element(channelView.begin(), channelView.end());
                     auto min = *(minMax.first);
@@ -723,7 +723,7 @@ void accumulateSkipEdgeFeaturesFromFiltersWithAccChain(
             for(auto nextId : skipSlices[sliceId] ) {
                 std::cout << "to slice " << nextId << std::endl;
 
-                beginB = Coord({int64_t(nextId),0L,0L});
+                beginB = Coord({int64_t(nextId),0LL,0LL});
                 endB   = Coord({int64_t(nextId+1),shape[1],shape[2]});
 
                 auto labelsB = labelsBStorage.getView(0);
@@ -892,8 +892,8 @@ void accumulateSkipEdgeFeaturesFromFilters(
                 }
             });
 
-            FeatCoord begin({int64_t(edgeOffset),0L});
-            FeatCoord end({edgeOffset+nEdges,nChannels*nStats});
+            FeatCoord begin({int64_t(edgeOffset),0LL});
+            FeatCoord end({edgeOffset+nEdges,uint64_t(nChannels*nStats)});
 
             tools::writeSubarray(edgeFeaturesOut, begin, end, featuresTemp);
         },

--- a/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_flat.hxx
+++ b/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_flat.hxx
@@ -128,7 +128,7 @@ void accumulateEdgeFeaturesFlatWithAccChain(
     uint64_t numberOfSlices = shape[0];
 
     Coord2 sliceShape2({shape[1], shape[2]});
-    Coord sliceShape3({1LL, shape[1], shape[2]});
+    Coord sliceShape3({int64_t(1), shape[1], shape[2]});
 
     // edge acc vectors for multiple threads
     std::vector<AccChainVectorType> perThreadAccChainVector(actualNumberOfThreads);
@@ -178,7 +178,7 @@ void accumulateEdgeFeaturesFlatWithAccChain(
             //std::cout << "Upper: " << sliceIdA << " Lower: " << sliceIdB << std::endl;
             auto & threadAccChainVec = perThreadAccChainVector[tid];
 
-            Coord beginA ({sliceIdA, 0LL, 0LL});
+            Coord beginA ({sliceIdA, int64_t(0), int64_t(0)});
             Coord endA({sliceIdA+1, shape[1], shape[2]});
 
             auto labelsA = labelsAStorage.getView(tid);
@@ -200,7 +200,7 @@ void accumulateEdgeFeaturesFlatWithAccChain(
             );
 
             // process upper slice
-            Coord beginB = Coord({sliceIdB,   0LL,       0LL});
+            Coord beginB = Coord({sliceIdB,   int64_t(0),       int64_t(0)});
             Coord endB   = Coord({sliceIdB+1, shape[1], shape[2]});
             marray::View<LabelType> labelsBSqueezed;
 

--- a/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_flat.hxx
+++ b/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_flat.hxx
@@ -120,7 +120,7 @@ void accumulateEdgeFeaturesFlatWithAccChain(
     typedef EDGE_ACC_CHAIN EdgeAccChainType;
     typedef std::vector<EdgeAccChainType>   AccChainVectorType;
 
-    const size_t actualNumberOfThreads = pOpts.getActualNumThreads();
+    const std::size_t actualNumberOfThreads = pOpts.getActualNumThreads();
 
     const auto & shape = rag.shape();
     const auto & labelsProxy = rag.labelsProxy();
@@ -255,7 +255,7 @@ void accumulateEdgeFeaturesFlatWithAccChain(
 
 
 // 9 features
-template<size_t DIM, class LABELS_PROXY, class DATA, class FEATURE_TYPE>
+template<std::size_t DIM, class LABELS_PROXY, class DATA, class FEATURE_TYPE>
 void accumulateEdgeFeaturesFlat(
     const GridRag<DIM, LABELS_PROXY> & rag,
     const DATA & data,
@@ -285,7 +285,7 @@ void accumulateEdgeFeaturesFlat(
     // threadpool
     nifty::parallel::ParallelOptions pOpts(numberOfThreads);
     nifty::parallel::ThreadPool threadpool(pOpts);
-    const size_t actualNumberOfThreads = pOpts.getActualNumThreads();
+    const std::size_t actualNumberOfThreads = pOpts.getActualNumThreads();
 
     accumulateEdgeFeaturesFlatWithAccChain<AccChainType>(
         rag,

--- a/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_flat.hxx
+++ b/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_flat.hxx
@@ -128,7 +128,7 @@ void accumulateEdgeFeaturesFlatWithAccChain(
     uint64_t numberOfSlices = shape[0];
 
     Coord2 sliceShape2({shape[1], shape[2]});
-    Coord sliceShape3({1L, shape[1], shape[2]});
+    Coord sliceShape3({1LL, shape[1], shape[2]});
 
     // edge acc vectors for multiple threads
     std::vector<AccChainVectorType> perThreadAccChainVector(actualNumberOfThreads);
@@ -178,7 +178,7 @@ void accumulateEdgeFeaturesFlatWithAccChain(
             //std::cout << "Upper: " << sliceIdA << " Lower: " << sliceIdB << std::endl;
             auto & threadAccChainVec = perThreadAccChainVector[tid];
 
-            Coord beginA ({sliceIdA, 0L, 0L});
+            Coord beginA ({sliceIdA, 0LL, 0LL});
             Coord endA({sliceIdA+1, shape[1], shape[2]});
 
             auto labelsA = labelsAStorage.getView(tid);
@@ -200,7 +200,7 @@ void accumulateEdgeFeaturesFlatWithAccChain(
             );
 
             // process upper slice
-            Coord beginB = Coord({sliceIdB,   0L,       0L});
+            Coord beginB = Coord({sliceIdB,   0LL,       0LL});
             Coord endB   = Coord({sliceIdB+1, shape[1], shape[2]});
             marray::View<LabelType> labelsBSqueezed;
 

--- a/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_stacked.hxx
+++ b/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_stacked.hxx
@@ -374,7 +374,7 @@ namespace graph{
         // threadpool
         nifty::parallel::ParallelOptions pOpts(numberOfThreads);
         nifty::parallel::ThreadPool threadpool(pOpts);
-        const size_t actualNumberOfThreads = pOpts.getActualNumThreads();
+        const std::size_t actualNumberOfThreads = pOpts.getActualNumThreads();
 
         // general accumulator function
         auto accFunction = [&threadpool](
@@ -435,16 +435,16 @@ namespace graph{
     template<class LABELS_PROXY>
     void getSkipEdgeLengths(
         const GridRagStacked2D<LABELS_PROXY> & rag,
-        std::vector<size_t> & out, // TODO call by ref or call by val ?
+        std::vector<std::size_t> & out, // TODO call by ref or call by val ?
         const std::vector<std::pair<uint64_t,uint64_t>> & skipEdges,
-        const std::vector<size_t> & skipRanges,
-        const std::vector<size_t> & skipStarts,
+        const std::vector<std::size_t> & skipRanges,
+        const std::vector<std::size_t> & skipStarts,
         const int numberOfThreads = -1
     ){
         // threadpool
         nifty::parallel::ParallelOptions pOpts(numberOfThreads);
         nifty::parallel::ThreadPool threadpool(pOpts);
-        const size_t actualNumberOfThreads = pOpts.getActualNumThreads();
+        const std::size_t actualNumberOfThreads = pOpts.getActualNumThreads();
         getSkipEdgeLengthsImpl(rag, out, skipEdges, skipRanges, skipStarts, pOpts, threadpool);
     }
 
@@ -452,10 +452,10 @@ namespace graph{
     template<class LABELS_PROXY>
     void getSkipEdgeLengthsImpl(
         const GridRagStacked2D<LABELS_PROXY> & rag,
-        std::vector<size_t> & out,
+        std::vector<std::size_t> & out,
         const std::vector<std::pair<uint64_t,uint64_t>> & skipEdges,
-        const std::vector<size_t> & skipRanges,
-        const std::vector<size_t> & skipStarts,
+        const std::vector<std::size_t> & skipRanges,
+        const std::vector<std::size_t> & skipStarts,
         const parallel::ParallelOptions & pOpts,
         parallel::ThreadPool & threadpool
     ){
@@ -467,9 +467,9 @@ namespace graph{
         typedef array::StaticArray<int64_t, 2> Coord2;
 
         typedef std::pair<uint64_t,uint64_t> SkipEdgeStorage;
-        typedef std::vector<size_t> EdgeLenVector;
+        typedef std::vector<std::size_t> EdgeLenVector;
 
-        const size_t actualNumberOfThreads = pOpts.getActualNumThreads();
+        const std::size_t actualNumberOfThreads = pOpts.getActualNumThreads();
 
         const auto & shape = rag.shape();
         const auto & labelsProxy = rag.labelsProxy();
@@ -481,23 +481,23 @@ namespace graph{
         LabelBlockStorage labelsBStorage(threadpool, sliceShape3, 1);
 
         // get unique lower slices with skip edges
-        std::vector<size_t> lowerSlices;
+        std::vector<std::size_t> lowerSlices;
         tools::uniques(skipStarts, lowerSlices);
         auto lowest = int64_t(lowerSlices[0]);
 
         // get upper slices with skip edges for each lower slice and number of skip edges for each lower slice
-        std::map<size_t,std::vector<size_t>> skipSlices;
-        std::map<size_t,size_t> numberOfSkipEdgesPerSlice;
+        std::map<std::size_t,std::vector<std::size_t>> skipSlices;
+        std::map<std::size_t,std::size_t> numberOfSkipEdgesPerSlice;
         // initialize the maps
         for(auto sliceId : lowerSlices) {
-            skipSlices[sliceId] = std::vector<size_t>();
+            skipSlices[sliceId] = std::vector<std::size_t>();
             numberOfSkipEdgesPerSlice[sliceId] = 0;
         }
 
         // determine the number of skip edges starting from each slice
         // and fill the conversion of uv-ids to edge-id
-        std::map<SkipEdgeStorage, size_t> skipUvsToIds;
-        for(size_t skipId = 0; skipId < skipEdges.size(); ++skipId) {
+        std::map<SkipEdgeStorage, std::size_t> skipUvsToIds;
+        for(std::size_t skipId = 0; skipId < skipEdges.size(); ++skipId) {
 
             // find the source slice of this skip edge and increment the number of edges in the slice
             auto sliceId = skipStarts[skipId];
@@ -514,7 +514,7 @@ namespace graph{
         }
 
         int countSlice = 0;
-        size_t skipEdgeOffset = 0;
+        std::size_t skipEdgeOffset = 0;
         for(auto sliceId : lowerSlices) {
 
             std::cout << countSlice++ << " / " << lowerSlices.size() << std::endl;
@@ -572,7 +572,7 @@ namespace graph{
             parallel::parallel_foreach(threadpool, skipEdgesInSlice, [&](const int tid, const int64_t skipId){
 
                 auto & outData = out[skipId + skipEdgeOffset];
-                for(size_t t = 0; t < actualNumberOfThreads; ++t) {
+                for(std::size_t t = 0; t < actualNumberOfThreads; ++t) {
                     auto & threadData = perThreadData[t];
                     outData += threadData[skipId];
                 }

--- a/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_stacked.hxx
+++ b/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_stacked.hxx
@@ -187,7 +187,7 @@ namespace graph{
 
         uint64_t numberOfSlices = shape[0];
         const Coord2 sliceShape2({shape[1], shape[2]});
-        const Coord  sliceShape3({1LL,shape[1], shape[2]});
+        const Coord  sliceShape3({int64_t(1),shape[1], shape[2]});
 
         // For now, we only support single pass!
         // do N passes of accumulator
@@ -204,8 +204,8 @@ namespace graph{
             DataCopyStorage dataBCopyStorage(threadpool, sliceShape2, nThreads);
 
             // process slice 0 to find min and max for histogram opts
-            Coord begin0({0LL, 0LL, 0LL});
-            Coord end0(  {1LL, shape[1], shape[2]});
+            Coord begin0({int64_t(0), int64_t(0), int64_t(0)});
+            Coord end0(  {int64_t(1), shape[1], shape[2]});
 
             auto data0 = dataAStorage.getView(0);
             tools::readSubarray(data, begin0, end0, data0);
@@ -235,7 +235,7 @@ namespace graph{
                 int64_t sliceIdB = slicePairs[pairId].second;// upper slice
 
                 // compute the filters for slice A
-                Coord beginA ({sliceIdA, 0LL, 0LL});
+                Coord beginA ({sliceIdA, int64_t(0), int64_t(0)});
                 Coord endA({sliceIdA+1, shape[1], shape[2]});
 
                 auto labelsA = labelsAStorage.getView(tid);
@@ -273,7 +273,7 @@ namespace graph{
 
                 // process upper slice
                 // TODO copy non-float data ?!
-                Coord beginB = Coord({sliceIdB,   0LL,       0LL});
+                Coord beginB = Coord({sliceIdB,   int64_t(0),       int64_t(0)});
                 Coord endB   = Coord({sliceIdB+1, shape[1], shape[2]});
                 marray::View<LabelType> labelsBSqueezed;
                 marray::View<DataType> dataBSqueezed;
@@ -400,7 +400,7 @@ namespace graph{
                     featuresTemp(edge, 2+qi) = replaceIfNotFinite(quantiles[qi], mean);
             }
 
-            FeatCoord begin({int64_t(edgeOffset),0LL});
+            FeatCoord begin({int64_t(edgeOffset),int64_t(0)});
             FeatCoord end({edgeOffset+nEdges, nStats});
 
             tools::writeSubarray(edgeFeaturesOut, begin, end, featuresTemp);
@@ -475,7 +475,7 @@ namespace graph{
         const auto & labelsProxy = rag.labelsProxy();
 
         Coord2 sliceShape2({shape[1], shape[2]});
-        Coord sliceShape3({1LL,shape[1], shape[2]});
+        Coord sliceShape3({int64_t(1),shape[1], shape[2]});
 
         LabelBlockStorage labelsAStorage(threadpool, sliceShape3, 1);
         LabelBlockStorage labelsBStorage(threadpool, sliceShape3, 1);
@@ -520,7 +520,7 @@ namespace graph{
             std::cout << countSlice++ << " / " << lowerSlices.size() << std::endl;
             std::cout << "Computing lengths for skip edges from slice " << sliceId << std::endl;
 
-            Coord beginA({int64_t(sliceId),0LL,0LL});
+            Coord beginA({int64_t(sliceId),int64_t(0),int64_t(0)});
             Coord endA(  {int64_t(sliceId+1),shape[1],shape[2]});
             auto labelsA = labelsAStorage.getView(0);
             labelsProxy.readSubarray(beginA, endA, labelsA);
@@ -535,7 +535,7 @@ namespace graph{
             for(auto nextId : skipSlices[sliceId] ) {
                 std::cout << "to slice " << nextId << std::endl;
 
-                beginB = Coord({int64_t(nextId),0LL,0LL});
+                beginB = Coord({int64_t(nextId),int64_t(0),int64_t(0)});
                 endB   = Coord({int64_t(nextId+1),shape[1],shape[2]});
 
                 auto labelsB = labelsBStorage.getView(0);

--- a/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_stacked.hxx
+++ b/include/nifty/graph/rag/feature_accumulation/grid_rag_accumulate_stacked.hxx
@@ -187,7 +187,7 @@ namespace graph{
 
         uint64_t numberOfSlices = shape[0];
         const Coord2 sliceShape2({shape[1], shape[2]});
-        const Coord  sliceShape3({1L,shape[1], shape[2]});
+        const Coord  sliceShape3({1LL,shape[1], shape[2]});
 
         // For now, we only support single pass!
         // do N passes of accumulator
@@ -204,8 +204,8 @@ namespace graph{
             DataCopyStorage dataBCopyStorage(threadpool, sliceShape2, nThreads);
 
             // process slice 0 to find min and max for histogram opts
-            Coord begin0({0L, 0L, 0L});
-            Coord end0(  {1L, shape[1], shape[2]});
+            Coord begin0({0LL, 0LL, 0LL});
+            Coord end0(  {1LL, shape[1], shape[2]});
 
             auto data0 = dataAStorage.getView(0);
             tools::readSubarray(data, begin0, end0, data0);
@@ -235,7 +235,7 @@ namespace graph{
                 int64_t sliceIdB = slicePairs[pairId].second;// upper slice
 
                 // compute the filters for slice A
-                Coord beginA ({sliceIdA, 0L, 0L});
+                Coord beginA ({sliceIdA, 0LL, 0LL});
                 Coord endA({sliceIdA+1, shape[1], shape[2]});
 
                 auto labelsA = labelsAStorage.getView(tid);
@@ -273,7 +273,7 @@ namespace graph{
 
                 // process upper slice
                 // TODO copy non-float data ?!
-                Coord beginB = Coord({sliceIdB,   0L,       0L});
+                Coord beginB = Coord({sliceIdB,   0LL,       0LL});
                 Coord endB   = Coord({sliceIdB+1, shape[1], shape[2]});
                 marray::View<LabelType> labelsBSqueezed;
                 marray::View<DataType> dataBSqueezed;
@@ -400,7 +400,7 @@ namespace graph{
                     featuresTemp(edge, 2+qi) = replaceIfNotFinite(quantiles[qi], mean);
             }
 
-            FeatCoord begin({int64_t(edgeOffset),0L});
+            FeatCoord begin({int64_t(edgeOffset),0LL});
             FeatCoord end({edgeOffset+nEdges, nStats});
 
             tools::writeSubarray(edgeFeaturesOut, begin, end, featuresTemp);
@@ -475,7 +475,7 @@ namespace graph{
         const auto & labelsProxy = rag.labelsProxy();
 
         Coord2 sliceShape2({shape[1], shape[2]});
-        Coord sliceShape3({1L,shape[1], shape[2]});
+        Coord sliceShape3({1LL,shape[1], shape[2]});
 
         LabelBlockStorage labelsAStorage(threadpool, sliceShape3, 1);
         LabelBlockStorage labelsBStorage(threadpool, sliceShape3, 1);
@@ -520,7 +520,7 @@ namespace graph{
             std::cout << countSlice++ << " / " << lowerSlices.size() << std::endl;
             std::cout << "Computing lengths for skip edges from slice " << sliceId << std::endl;
 
-            Coord beginA({int64_t(sliceId),0L,0L});
+            Coord beginA({int64_t(sliceId),0LL,0LL});
             Coord endA(  {int64_t(sliceId+1),shape[1],shape[2]});
             auto labelsA = labelsAStorage.getView(0);
             labelsProxy.readSubarray(beginA, endA, labelsA);
@@ -535,7 +535,7 @@ namespace graph{
             for(auto nextId : skipSlices[sliceId] ) {
                 std::cout << "to slice " << nextId << std::endl;
 
-                beginB = Coord({int64_t(nextId),0L,0L});
+                beginB = Coord({int64_t(nextId),0LL,0LL});
                 endB   = Coord({int64_t(nextId+1),shape[1],shape[2]});
 
                 auto labelsB = labelsBStorage.getView(0);

--- a/include/nifty/graph/rag/feature_accumulation/grid_rag_affinity_features.hxx
+++ b/include/nifty/graph/rag/feature_accumulation/grid_rag_affinity_features.hxx
@@ -38,7 +38,7 @@ void accumulateAffninitiesWithAccChain(
 
     // only single threaded for now
     // accumulator chain vectors for local and lifted edges
-    size_t nEdges = rag.edgeIdUpperBound() + 1;
+    std::size_t nEdges = rag.edgeIdUpperBound() + 1;
     AccChainVectorType edgeAccumulators(nEdges);
 
     // set the histogram options
@@ -54,8 +54,8 @@ void accumulateAffninitiesWithAccChain(
 
     // axes and reanges from the lifted nhood
     // TODO don't hardcode this
-    std::array<int, 3> axes({0, 1, 2});
-    std::array<int, 3> ranges({-1, -1, -1});
+    std::array<int, 3> axes{0, 1, 2};
+    std::array<int, 3> ranges{-1, -1, -1};
 
     Coord4 affCoord;
     Coord3 cU, cV;
@@ -63,10 +63,10 @@ void accumulateAffninitiesWithAccChain(
     int axis, range;
     int pass = 1;
 
-    size_t nLinks = affinities.size();
+    std::size_t nLinks = affinities.size();
     // iterate over all affinity links and accumulate the associated
     // affinity edges
-    for(size_t linkId = 0; linkId < nLinks; ++linkId) {
+    for(std::size_t linkId = 0; linkId < nLinks; ++linkId) {
 
         affinities.indexToCoordinates(linkId, affCoord.begin());
         axis  = axes[affCoord[0]];
@@ -130,7 +130,7 @@ void accumulateAffinities(
     // threadpool
     nifty::parallel::ParallelOptions pOpts(numberOfThreads);
     nifty::parallel::ThreadPool threadpool(pOpts);
-    const size_t actualNumberOfThreads = pOpts.getActualNumThreads();
+    const std::size_t actualNumberOfThreads = pOpts.getActualNumThreads();
 
     auto accumulate = [&](
         const std::vector<AccChainType> & edgeAccChainVec
@@ -196,8 +196,8 @@ void accumulateLongRangeAffninitiesWithAccChain(
 
     // only single threaded for now
     // accumulator chain vectors for local and lifted edges
-    size_t nLocal = rag.edgeIdUpperBound() + 1;
-    size_t nLifted = lnh.edgeIdUpperBound() + 1;
+    std::size_t nLocal = rag.edgeIdUpperBound() + 1;
+    std::size_t nLifted = lnh.edgeIdUpperBound() + 1;
     AccChainVectorType localEdgeAccumulators(nLocal);
     AccChainVectorType liftedEdgeAccumulators(nLifted);
 
@@ -227,10 +227,10 @@ void accumulateLongRangeAffninitiesWithAccChain(
     int axis, range;
     int pass = 1;
 
-    size_t nLinks = affinities.size();
+    std::size_t nLinks = affinities.size();
     // iterate over all affinity links and accumulate the associated
     // affinity edges
-    for(size_t linkId = 0; linkId < nLinks; ++linkId) {
+    for(std::size_t linkId = 0; linkId < nLinks; ++linkId) {
 
         affinities.indexToCoordinates(linkId, affCoord.begin());
         axis  = axes[affCoord[0]];
@@ -303,7 +303,7 @@ void accumulateLongRangeAffinities(
     // threadpool
     nifty::parallel::ParallelOptions pOpts(numberOfThreads);
     nifty::parallel::ThreadPool threadpool(pOpts);
-    const size_t actualNumberOfThreads = pOpts.getActualNumThreads();
+    const std::size_t actualNumberOfThreads = pOpts.getActualNumThreads();
 
     auto accumulateLocal = [&](
         const std::vector<AccChainType> & edgeAccChainVec

--- a/include/nifty/graph/rag/feature_accumulation/lifted_nh.hxx
+++ b/include/nifty/graph/rag/feature_accumulation/lifted_nh.hxx
@@ -45,7 +45,7 @@ private:
 
     std::vector<int> ranges_;
     std::vector<int> axes_;
-    std::vector<size_t> lrIndices_;
+    std::vector<std::size_t> lrIndices_;
 };
 
 
@@ -61,32 +61,32 @@ void LiftedNh<RAG>::initLiftedNh(
     // set the number of nodes in the graph == number of labels
     BaseType::assign(rag.labelsProxy().numberOfLabels());
     Coord3 shape;
-    for(size_t d = 0; d < 3; ++d) {
+    for(std::size_t d = 0; d < 3; ++d) {
         shape[d] = labels.shape(d);
     }
 
     // TODO parallelize properly
     // threadpool and actual number of threads
     //nifty::parallel::ThreadPool threadpool(numberOfThreads);
-    //const size_t nThreads = threadpool.nThreads();
+    //const std::size_t nThreads = threadpool.nThreads();
 
     //
     // get the lr edges (== ranges with abs value bigger than 1)
     //
 
-    for(size_t ii = 0; ii < ranges_.size(); ++ii) {
+    for(std::size_t ii = 0; ii < ranges_.size(); ++ii) {
         if(std::abs(ranges_[ii]) > 1) {
             lrIndices_.push_back(ii);
         }
     }
 
     // number of links = number of lr channels * number of pixels
-    size_t nLinks = lrIndices_.size() * labels.size();
+    std::size_t nLinks = lrIndices_.size() * labels.size();
 
     // FIXME super dirty hack to get the index to offsets translator from marray
     Coord4 affShape;
     affShape[0] = lrIndices_.size();
-    for(size_t d = 0; d < 3; ++d) {
+    for(std::size_t d = 0; d < 3; ++d) {
         affShape[d+1] = shape[d];
     }
 
@@ -100,13 +100,13 @@ void LiftedNh<RAG>::initLiftedNh(
     Coord4 affCoord;
     Coord3 cU, cV;
     int axis, range, lrId;
-    for(size_t linkId = 0; linkId < nLinks; ++linkId) {
+    for(std::size_t linkId = 0; linkId < nLinks; ++linkId) {
         fakeAffinities.indexToCoordinates(linkId, affCoord.begin());
         lrId = lrIndices_[affCoord[0]];
         axis  = axes_[lrId];
         range = ranges_[lrId];
 
-        for(size_t d = 0; d < 3; ++d) {
+        for(std::size_t d = 0; d < 3; ++d) {
             cU[d] = affCoord[d+1];
             cV[d] = affCoord[d+1];
         }

--- a/include/nifty/graph/rag/grid_rag.hxx
+++ b/include/nifty/graph/rag/grid_rag.hxx
@@ -30,14 +30,14 @@ namespace graph{
 
 
 template<class COORD>
-COORD makeCoord2(const COORD & coord,const size_t axis){
+COORD makeCoord2(const COORD & coord,const std::size_t axis){
     COORD coord2 = coord;
     coord2[axis] += 1;
     return coord2;
 };
 
 
-template<size_t DIM, class LABEL_TYPE>
+template<std::size_t DIM, class LABEL_TYPE>
 class ExplicitLabels;
 
 template<class LABELS_PROXY>
@@ -45,14 +45,14 @@ struct RefHelper{
     typedef const LABELS_PROXY & type;
 };
 
-template<size_t DIM, class LABEL_TYPE>
+template<std::size_t DIM, class LABEL_TYPE>
 struct RefHelper<ExplicitLabels<DIM, LABEL_TYPE>>{
     typedef ExplicitLabels<DIM, LABEL_TYPE> type;
 };
 
 
 
-template<size_t DIM, class LABELS_PROXY>
+template<std::size_t DIM, class LABELS_PROXY>
 class GridRag : public UndirectedGraph<>{
 public:
     struct DontComputeRag{};

--- a/include/nifty/graph/rag/grid_rag_coordinates.hxx
+++ b/include/nifty/graph/rag/grid_rag_coordinates.hxx
@@ -16,7 +16,7 @@ namespace nifty {
 namespace graph {
 
     // TODO implementations suitable for hdf5 and flat rag
-    template<size_t DIM, class RAG_TYPE>
+    template<std::size_t DIM, class RAG_TYPE>
     class RagCoordinates {
 
     public:
@@ -57,7 +57,7 @@ namespace graph {
             return rag_;
         }
 
-        size_t storageLengths() const {
+        std::size_t storageLengths() const {
             return storage_.size();
         }
 
@@ -105,7 +105,7 @@ namespace graph {
     };
 
 
-    template<size_t DIM, class RAG_TYPE>
+    template<std::size_t DIM, class RAG_TYPE>
     template<class T>
     inline void RagCoordinates<DIM, RAG_TYPE>::writeBothCoordinates(const int64_t edgeId, const T edgeVal, marray::View<T> & out, const std::vector<int64_t> & offset) const {
 
@@ -115,8 +115,8 @@ namespace graph {
             outShape[d] = out.shape(d);
         }
 
-        for(size_t ii = 0; ii < coords.size() / DIM; ++ii) {
-            for(size_t d = 0; d < DIM; ++d) {
+        for(std::size_t ii = 0; ii < coords.size() / DIM; ++ii) {
+            for(std::size_t d = 0; d < DIM; ++d) {
                 coordUp[d] = static_cast<int64_t>( ceil(float(coords[DIM * ii + d]) / 2) );
                 coordDn[d] = static_cast<int64_t>( floor(float(coords[DIM * ii + d]) / 2) );
             }
@@ -136,7 +136,7 @@ namespace graph {
     }
 
 
-    template<size_t DIM, class RAG_TYPE>
+    template<std::size_t DIM, class RAG_TYPE>
     template<class T>
     inline void RagCoordinates<DIM, RAG_TYPE>::writeLowerCoordinates(const int64_t edgeId, const T edgeVal, marray::View<T> & out, const std::vector<int64_t> & offset) const {
 
@@ -146,8 +146,8 @@ namespace graph {
             outShape[d] = out.shape(d);
         }
 
-        for(size_t ii = 0; ii < coords.size() / DIM; ++ii) {
-            for(size_t d = 0; d < DIM; ++d) {
+        for(std::size_t ii = 0; ii < coords.size() / DIM; ++ii) {
+            for(std::size_t d = 0; d < DIM; ++d) {
                 coord[d] = static_cast<int64_t>( floor(float(coords[DIM * ii + d]) / 2) );
             }
             if( !offset.empty() ) {
@@ -160,7 +160,7 @@ namespace graph {
     }
 
 
-    template<size_t DIM, class RAG_TYPE>
+    template<std::size_t DIM, class RAG_TYPE>
     template<class T>
     inline void RagCoordinates<DIM, RAG_TYPE>::writeUpperCoordinates(const int64_t edgeId, const T edgeVal, marray::View<T> & out, const std::vector<int64_t> & offset) const {
 
@@ -170,8 +170,8 @@ namespace graph {
             outShape[d] = out.shape(d);
         }
 
-        for(size_t ii = 0; ii < coords.size() / DIM; ++ii) {
-            for(size_t d = 0; d < DIM; ++d) {
+        for(std::size_t ii = 0; ii < coords.size() / DIM; ++ii) {
+            for(std::size_t d = 0; d < DIM; ++d) {
                 coord[d] = static_cast<int64_t>( ceil(float(coords[DIM * ii + d]) / 2) );
             }
             if( !offset.empty() ) {
@@ -184,7 +184,7 @@ namespace graph {
     }
 
 
-    template<size_t DIM, class RAG_TYPE>
+    template<std::size_t DIM, class RAG_TYPE>
     void RagCoordinates<DIM, RAG_TYPE>::initStorage(const int nThreads) {
 
         typedef std::vector<std::vector<int32_t>> CoordinateVectorType;
@@ -204,10 +204,10 @@ namespace graph {
 
         nifty::parallel::ThreadPool threadpool(nThreads);
         std::vector<CoordinateVectorType> perThreadDataVec(threadpool.nThreads());
-        for(size_t i=0; i<perThreadDataVec.size(); ++i)
+        for(std::size_t i=0; i<perThreadDataVec.size(); ++i)
             perThreadDataVec[i].resize(numEdges);
 
-        auto makeCoord2 = [](const Coord & coord,const size_t axis){
+        auto makeCoord2 = [](const Coord & coord,const std::size_t axis){
             Coord coord2 = coord;
             coord2[axis] += 1;
             return coord2;
@@ -218,7 +218,7 @@ namespace graph {
 
             auto & edgeCoords = perThreadDataVec[tid];
             const auto lU = labels(coord.asStdArray());
-            for(size_t axis=0; axis<DIM; ++axis){
+            for(std::size_t axis=0; axis<DIM; ++axis){
                 const auto coord2 = makeCoord2(coord, axis);
                 if(coord2[axis] < shape[axis]){
                     const auto lV = labels(coord2.asStdArray());
@@ -246,7 +246,7 @@ namespace graph {
     }
 
 
-    template<size_t DIM, class RAG_TYPE>
+    template<std::size_t DIM, class RAG_TYPE>
     template<class T>
     void RagCoordinates<DIM, RAG_TYPE>::edgesToVolume(
             const std::vector<T> & edgeValues,
@@ -284,7 +284,7 @@ namespace graph {
     }
 
 
-    template<size_t DIM, class RAG_TYPE>
+    template<std::size_t DIM, class RAG_TYPE>
     template<class T>
     void RagCoordinates<DIM, RAG_TYPE>::edgesToSubVolume(
             const std::vector<T> & edgeValues,

--- a/include/nifty/graph/rag/grid_rag_features.hxx
+++ b/include/nifty/graph/rag/grid_rag_features.hxx
@@ -10,7 +10,7 @@ namespace nifty{
 namespace graph{
 
 
-    template<size_t DIM, class LABELS_TYPE, class LABELS, class NODE_MAP>
+    template<std::size_t DIM, class LABELS_TYPE, class LABELS, class NODE_MAP>
     void gridRagAccumulateLabels(
         const ExplicitLabelsGridRag<DIM, LABELS_TYPE> & graph,
         nifty::marray::View<LABELS> data,
@@ -24,7 +24,7 @@ namespace graph{
         const auto & shape = labelsProxy.shape();
         const auto labels = labelsProxy.labels();
 
-        std::vector<  std::unordered_map<LABELS, size_t> > overlaps(graph.numberOfNodes());
+        std::vector<  std::unordered_map<LABELS, std::size_t> > overlaps(graph.numberOfNodes());
 
 
 
@@ -37,7 +37,7 @@ namespace graph{
         for(const auto node : graph.nodes()){
             const auto & ol = overlaps[node];
             // find max ol
-            size_t maxOl = 0;
+            std::size_t maxOl = 0;
             LABELS maxOlLabel = 0;
             for(auto kv : ol){
                 if(kv.second > maxOl){

--- a/include/nifty/graph/rag/grid_rag_features_stacked.hxx
+++ b/include/nifty/graph/rag/grid_rag_features_stacked.hxx
@@ -48,7 +48,7 @@ namespace graph{
         
         uint64_t numberOfSlices = shape[0];
         Coord2 sliceShape2({shape[1], shape[2]});
-        Coord sliceShape3({1L,shape[1], shape[2]});
+        Coord sliceShape3({1LL,shape[1], shape[2]});
 
         std::vector<  std::unordered_map<uint64_t, uint64_t> > overlaps(graph.numberOfNodes());
         
@@ -61,7 +61,7 @@ namespace graph{
             auto sliceLabelsFlat3DView = sliceLabelsStorage.getView(tid);
             auto sliceDataFlat3DView   = sliceDataStorage.getView(tid);
             
-            const Coord blockBegin({sliceIndex,0L,0L});
+            const Coord blockBegin({sliceIndex,0LL,0LL});
             const Coord blockEnd({sliceIndex+1, sliceShape2[0], sliceShape2[1]});
             
             tools::readSubarray(labelsProxy, blockBegin, blockEnd, sliceLabelsFlat3DView);
@@ -123,9 +123,9 @@ namespace graph{
         if(upperSegIt == upperSegMap.end()) { // this is the first time we reach this upper slice, so we need to read the labels from hdf5
             
             auto & shape = labels.shape();
-            Coord sliceShape({1L, shape[1], shape[2]});
+            Coord sliceShape({1LL, shape[1], shape[2]});
             upperSegMap[zUp] = tools::make_unique<marray::Marray<NodeType>>(sliceShape.begin(), sliceShape.end()); // C++ 14 ?!
-            Coord sliceUpStart({zUp, 0L, 0L});
+            Coord sliceUpStart({zUp, 0LL, 0LL});
             Coord sliceUpStop({zUp+1, shape[1], shape[2]});
             
             std::cout << "Read Upper slice: " << zUp << std::endl;
@@ -201,12 +201,12 @@ namespace graph{
         
         auto edgeOffset = rag.numberOfInSliceEdges();
         
-        Coord sliceShape({1L, shape[1], shape[2]});
+        Coord sliceShape({1LL, shape[1], shape[2]});
         Coord2 sliceShape2({shape[1], shape[2]});
         
         // read the segmentation in the defected slice
         marray::Marray<NodeType> segZArray(sliceShape.begin(), sliceShape.end());
-        Coord sliceStart({z, 0L, 0L});
+        Coord sliceStart({z, 0LL, 0LL});
         Coord sliceStop({z+1, shape[1], shape[2]});
         
         std::cout << "Read defected slice: " << z << std::endl;
@@ -215,7 +215,7 @@ namespace graph{
             
         // read the segmentation in the lower slice
         marray::Marray<NodeType> segDnArray(sliceShape.begin(), sliceShape.end());
-        Coord sliceDnStart({z-1, 0L, 0L});
+        Coord sliceDnStart({z-1, 0LL, 0LL});
         Coord sliceDnStop({z, shape[1], shape[2]});
          
         // don't need lower segmentation for first and last slice or if the lower slice is completely defected
@@ -234,7 +234,7 @@ namespace graph{
         // TODO do we need a pointer here?
         std::map<int64_t, std::unique_ptr<marray::Marray<NodeType>>> upperSegMap;
         upperSegMap[z+1] = tools::make_unique<marray::Marray<NodeType>>(sliceShape.begin(), sliceShape.end()); // C++ 14 ?!
-        Coord sliceUpStart({z+1, 0L, 0L});
+        Coord sliceUpStart({z+1, 0LL, 0LL});
         Coord sliceUpStop({z+2, shape[1], shape[2]});
         
         // don't need upper segmentation for first and last slice or if the lower slice is completely defected

--- a/include/nifty/graph/rag/grid_rag_features_stacked.hxx
+++ b/include/nifty/graph/rag/grid_rag_features_stacked.hxx
@@ -48,7 +48,7 @@ namespace graph{
         
         uint64_t numberOfSlices = shape[0];
         Coord2 sliceShape2({shape[1], shape[2]});
-        Coord sliceShape3({1LL,shape[1], shape[2]});
+        Coord sliceShape3({int64_t(1),shape[1], shape[2]});
 
         std::vector<  std::unordered_map<uint64_t, uint64_t> > overlaps(graph.numberOfNodes());
         
@@ -61,7 +61,7 @@ namespace graph{
             auto sliceLabelsFlat3DView = sliceLabelsStorage.getView(tid);
             auto sliceDataFlat3DView   = sliceDataStorage.getView(tid);
             
-            const Coord blockBegin({sliceIndex,0LL,0LL});
+            const Coord blockBegin({sliceIndex,int64_t(0),int64_t(0)});
             const Coord blockEnd({sliceIndex+1, sliceShape2[0], sliceShape2[1]});
             
             tools::readSubarray(labelsProxy, blockBegin, blockEnd, sliceLabelsFlat3DView);
@@ -123,9 +123,9 @@ namespace graph{
         if(upperSegIt == upperSegMap.end()) { // this is the first time we reach this upper slice, so we need to read the labels from hdf5
             
             auto & shape = labels.shape();
-            Coord sliceShape({1LL, shape[1], shape[2]});
+            Coord sliceShape({int64_t(1), shape[1], shape[2]});
             upperSegMap[zUp] = tools::make_unique<marray::Marray<NodeType>>(sliceShape.begin(), sliceShape.end()); // C++ 14 ?!
-            Coord sliceUpStart({zUp, 0LL, 0LL});
+            Coord sliceUpStart({zUp, int64_t(0), int64_t(0)});
             Coord sliceUpStop({zUp+1, shape[1], shape[2]});
             
             std::cout << "Read Upper slice: " << zUp << std::endl;
@@ -201,12 +201,12 @@ namespace graph{
         
         auto edgeOffset = rag.numberOfInSliceEdges();
         
-        Coord sliceShape({1LL, shape[1], shape[2]});
+        Coord sliceShape({int64_t(1), shape[1], shape[2]});
         Coord2 sliceShape2({shape[1], shape[2]});
         
         // read the segmentation in the defected slice
         marray::Marray<NodeType> segZArray(sliceShape.begin(), sliceShape.end());
-        Coord sliceStart({z, 0LL, 0LL});
+        Coord sliceStart({z, int64_t(0), int64_t(0)});
         Coord sliceStop({z+1, shape[1], shape[2]});
         
         std::cout << "Read defected slice: " << z << std::endl;
@@ -215,7 +215,7 @@ namespace graph{
             
         // read the segmentation in the lower slice
         marray::Marray<NodeType> segDnArray(sliceShape.begin(), sliceShape.end());
-        Coord sliceDnStart({z-1, 0LL, 0LL});
+        Coord sliceDnStart({z-1, int64_t(0), int64_t(0)});
         Coord sliceDnStop({z, shape[1], shape[2]});
          
         // don't need lower segmentation for first and last slice or if the lower slice is completely defected
@@ -234,7 +234,7 @@ namespace graph{
         // TODO do we need a pointer here?
         std::map<int64_t, std::unique_ptr<marray::Marray<NodeType>>> upperSegMap;
         upperSegMap[z+1] = tools::make_unique<marray::Marray<NodeType>>(sliceShape.begin(), sliceShape.end()); // C++ 14 ?!
-        Coord sliceUpStart({z+1, 0LL, 0LL});
+        Coord sliceUpStart({z+1, int64_t(0), int64_t(0)});
         Coord sliceUpStop({z+2, shape[1], shape[2]});
         
         // don't need upper segmentation for first and last slice or if the lower slice is completely defected

--- a/include/nifty/graph/rag/grid_rag_features_stacked.hxx
+++ b/include/nifty/graph/rag/grid_rag_features_stacked.hxx
@@ -99,7 +99,7 @@ namespace graph{
         const LABELS_PROXY & labels,
         const int64_t zUp,
         const int64_t zDn,
-        std::map<size_t,std::vector<NODE_TYPE>> & defectNodes, 
+        std::map<std::size_t,std::vector<NODE_TYPE>> & defectNodes, 
         const marray::View<NODE_TYPE> & segDn,
         const std::vector<NODE_TYPE> & nodesDn,
         std::map<NODE_TYPE,std::vector<array::StaticArray<int64_t,2>>> & coordsToNodesDn,
@@ -107,7 +107,7 @@ namespace graph{
         std::map<int64_t,
             std::unique_ptr<marray::Marray<NODE_TYPE>>> & upperSegMap,
         std::vector<std::pair<NODE_TYPE,NODE_TYPE>> & skipEdges,
-        std::vector<size_t> & skipRanges
+        std::vector<std::size_t> & skipRanges
     ){
         typedef NODE_TYPE NodeType;
         typedef array::StaticArray<int64_t, 3> Coord;
@@ -116,7 +116,7 @@ namespace graph{
         skipEdges.clear();
         skipRanges.clear();
         
-        size_t skipRange = zUp - zDn;
+        std::size_t skipRange = zUp - zDn;
             
         // read the upper segmentation
         auto upperSegIt = upperSegMap.find(zUp);
@@ -182,11 +182,11 @@ namespace graph{
     void getSkipEdgesForSlice(
         const GridRagStacked2D<LABELS_PROXY> & rag,
         const int64_t z,
-        std::map<size_t,std::vector<NODE_TYPE>> & defectNodes,
+        std::map<std::size_t,std::vector<NODE_TYPE>> & defectNodes,
         std::vector<EDGE_TYPE> & deleteEdges, // ref to outvec
         std::vector<EDGE_TYPE> & ignoreEdges, // ref to outvec
         std::vector<std::pair<NODE_TYPE,NODE_TYPE>> & skipEdges, // skip edges, ref to outvec
-        std::vector<size_t> & skipRanges, // skip ranges,ref to outvec
+        std::vector<std::size_t> & skipRanges, // skip ranges,ref to outvec
         const bool lowerIsCompletelyDefected = false
     ){
 
@@ -250,7 +250,7 @@ namespace graph{
 
         std::vector<Coord2> coordsUPrev;
 
-        for(size_t i = 0; i < defectNodesZ.size(); ++i) {
+        for(std::size_t i = 0; i < defectNodesZ.size(); ++i) {
 
             auto u = defectNodesZ[i];
 
@@ -311,7 +311,7 @@ namespace graph{
                 tools::valuesToCoordinatesWithCoordinates<2,NodeType>(segDn, coordsU, coordsToNodesDn);
 
                 std::vector<std::pair<NodeType,NodeType>> skipEdgesU;
-                std::vector<size_t> skipRangesU;
+                std::vector<std::size_t> skipRangesU;
                 
                 getSkipEdgesForNode(
                     labelsProxy,

--- a/include/nifty/graph/rag/grid_rag_stacked_2d.hxx
+++ b/include/nifty/graph/rag/grid_rag_stacked_2d.hxx
@@ -103,7 +103,7 @@ public:
     uint64_t numberOfInBetweenSliceEdges() const {
         return numberOfInBetweenSliceEdges_;
     }
-    const std::vector<size_t> & edgeLengths() const {
+    const std::vector<std::size_t> & edgeLengths() const {
         return edgeLengths_;
     }
 
@@ -120,7 +120,7 @@ private:
     std::vector<PerSliceData> perSliceDataVec_;
     uint64_t numberOfInSliceEdges_;
     uint64_t numberOfInBetweenSliceEdges_;
-    std::vector<size_t> edgeLengths_;
+    std::vector<std::size_t> edgeLengths_;
 };
 
 template<class LABEL_PROXY>

--- a/include/nifty/graph/rag/project_to_pixels.hxx
+++ b/include/nifty/graph/rag/project_to_pixels.hxx
@@ -16,7 +16,7 @@ namespace graph{
 
 
 template<
-    size_t DIM, 
+    std::size_t DIM, 
     class LABELS_TYPE, 
     class PIXEL_ARRAY, 
     class NODE_MAP

--- a/include/nifty/graph/rag/project_to_pixels_stacked.hxx
+++ b/include/nifty/graph/rag/project_to_pixels_stacked.hxx
@@ -45,7 +45,7 @@ void projectScalarNodeDataToPixels(
 
     uint64_t numberOfSlices = shape[0];
     Coord2 sliceShape2({shape[1], shape[2]});
-    Coord sliceShape3({1L,shape[1], shape[2]});
+    Coord sliceShape3({1LL,shape[1], shape[2]});
 
     LabelsBlockStorage sliceLabelsStorage(threadpool, sliceShape3, nThreads);
     DataBlockStorage   sliceDataStorage(threadpool, sliceShape3, nThreads);
@@ -56,7 +56,7 @@ void projectScalarNodeDataToPixels(
         auto sliceLabelsFlat3DView = sliceLabelsStorage.getView(tid);
         auto sliceDataFlat3DView   = sliceDataStorage.getView(tid);
 
-        const Coord blockBegin({sliceIndex,0L,0L});
+        const Coord blockBegin({sliceIndex,0LL,0LL});
         const Coord blockEnd({sliceIndex+1, sliceShape2[0], sliceShape2[1]});
 
         tools::readSubarray(labelsProxy, blockBegin, blockEnd, sliceLabelsFlat3DView);
@@ -106,7 +106,7 @@ void projectScalarNodeDataInSubBlock(
 
     uint64_t numberOfSlices = blockEnd[0] - blockBegin[0];
     Coord2 sliceShape2({blockEnd[1] - blockBegin[1], blockEnd[2] - blockBegin[2]});
-    Coord  sliceShape3({1L, blockEnd[1] - blockBegin[1], blockEnd[2] - blockBegin[2]});
+    Coord  sliceShape3({1LL, blockEnd[1] - blockBegin[1], blockEnd[2] - blockBegin[2]});
 
     LabelsBlockStorage sliceLabelsStorage(threadpool, sliceShape3, nThreads);
     DataBlockStorage   sliceDataStorage(threadpool, sliceShape3, nThreads);
@@ -131,7 +131,7 @@ void projectScalarNodeDataInSubBlock(
             sliceData(coord.asStdArray()) = nodeData[node];
         });
 
-        const Coord localBegin({sliceIndex, 0L, 0L});
+        const Coord localBegin({sliceIndex, 0LL, 0LL});
         const Coord localEnd({sliceIndex+1, sliceShape3[1], sliceShape3[2]});
 
         tools::writeSubarray(pixelData, localBegin, localEnd, sliceDataFlat3DView);

--- a/include/nifty/graph/rag/project_to_pixels_stacked.hxx
+++ b/include/nifty/graph/rag/project_to_pixels_stacked.hxx
@@ -45,7 +45,7 @@ void projectScalarNodeDataToPixels(
 
     uint64_t numberOfSlices = shape[0];
     Coord2 sliceShape2({shape[1], shape[2]});
-    Coord sliceShape3({1LL,shape[1], shape[2]});
+    Coord sliceShape3({int64_t(1),shape[1], shape[2]});
 
     LabelsBlockStorage sliceLabelsStorage(threadpool, sliceShape3, nThreads);
     DataBlockStorage   sliceDataStorage(threadpool, sliceShape3, nThreads);
@@ -56,7 +56,7 @@ void projectScalarNodeDataToPixels(
         auto sliceLabelsFlat3DView = sliceLabelsStorage.getView(tid);
         auto sliceDataFlat3DView   = sliceDataStorage.getView(tid);
 
-        const Coord blockBegin({sliceIndex,0LL,0LL});
+        const Coord blockBegin({sliceIndex,int64_t(0),int64_t(0)});
         const Coord blockEnd({sliceIndex+1, sliceShape2[0], sliceShape2[1]});
 
         tools::readSubarray(labelsProxy, blockBegin, blockEnd, sliceLabelsFlat3DView);
@@ -106,7 +106,7 @@ void projectScalarNodeDataInSubBlock(
 
     uint64_t numberOfSlices = blockEnd[0] - blockBegin[0];
     Coord2 sliceShape2({blockEnd[1] - blockBegin[1], blockEnd[2] - blockBegin[2]});
-    Coord  sliceShape3({1LL, blockEnd[1] - blockBegin[1], blockEnd[2] - blockBegin[2]});
+    Coord  sliceShape3({int64_t(1), blockEnd[1] - blockBegin[1], blockEnd[2] - blockBegin[2]});
 
     LabelsBlockStorage sliceLabelsStorage(threadpool, sliceShape3, nThreads);
     DataBlockStorage   sliceDataStorage(threadpool, sliceShape3, nThreads);
@@ -131,7 +131,7 @@ void projectScalarNodeDataInSubBlock(
             sliceData(coord.asStdArray()) = nodeData[node];
         });
 
-        const Coord localBegin({sliceIndex, 0LL, 0LL});
+        const Coord localBegin({sliceIndex, int64_t(0), int64_t(0)});
         const Coord localEnd({sliceIndex+1, sliceShape3[1], sliceShape3[2]});
 
         tools::writeSubarray(pixelData, localBegin, localEnd, sliceDataFlat3DView);

--- a/include/nifty/graph/shortest_path_dijkstra.hxx
+++ b/include/nifty/graph/shortest_path_dijkstra.hxx
@@ -61,7 +61,7 @@ namespace graph{
             DefaultSubgraphMask<Graph> subgraphMask;
 
             // visitor
-            size_t trgtsFound = 0;
+            std::size_t trgtsFound = 0;
             auto visitor = [&targets, &trgtsFound]
             (
                 int64_t topNode,

--- a/include/nifty/graph/undirected_grid_graph.hxx
+++ b/include/nifty/graph/undirected_grid_graph.hxx
@@ -336,7 +336,7 @@ public:
 
             // find the correct affinity edge
             AffinityCoordType affCoord;
-            for(size_t d = 0; d < DIM; ++d) {
+            for(std::size_t d = 0; d < DIM; ++d) {
                 auto diff = cU[d] - cV[d];
                 if(diff == 0) {
                     affCoord[d + 1] = cU[d];
@@ -364,21 +364,21 @@ public:
         for(auto d=1; d<DIM+1; ++d){
             NIFTY_CHECK_OP(shape(d-1), ==, affinities.shape(d), "wrong shape")
         }
-        size_t affLen = affinities.shape(0);
+        std::size_t affLen = affinities.shape(0);
         std::vector<int> ranges(rangesBegin, rangesBegin + affLen);
         std::vector<int> axes(axesBegin, axesBegin + affLen);
 
         AffinityCoordType affCoord;
         CoordinateType cU, cV;
-        size_t axis, range;
+        std::size_t axis, range;
 
         // iterate over the affinties
-        for(size_t edgeId = 0; edgeId < affinities.size(); ++edgeId) {
+        for(std::size_t edgeId = 0; edgeId < affinities.size(); ++edgeId) {
             affinities.indexToCoordinates(edgeId, affCoord.begin());
             axis  = axes[affCoord[0]];
             range = ranges[affCoord[0]];
 
-            for(size_t d = 0; d < DIM; ++d) {
+            for(std::size_t d = 0; d < DIM; ++d) {
                 cU[d] = affCoord[d+1];
                 cV[d] = affCoord[d+1];
             }

--- a/include/nifty/graph/undirected_list_graph.hxx
+++ b/include/nifty/graph/undirected_list_graph.hxx
@@ -471,7 +471,7 @@ extractSubgraphFromNodes(
         std::vector<EDGE_INTERANL_TYPE> & outerEdgesOut) const {
 
     std::map<NodeInteralType,NodeInteralType> globalToLocalNodes;
-    for(size_t i = 0; i < nodeList.size(); ++i)
+    for(std::size_t i = 0; i < nodeList.size(); ++i)
         globalToLocalNodes.insert( std::make_pair(nodeList[i], NodeInteralType(i)) );
 
     for(auto u : nodeList) {

--- a/include/nifty/ground_truth/overlap.hxx
+++ b/include/nifty/ground_truth/overlap.hxx
@@ -199,7 +199,7 @@ namespace ground_truth{
         }
 
 
-        template<size_t DIM, class LABEL_A, class LABEL_B>
+        template<std::size_t DIM, class LABEL_A, class LABEL_B>
         void fill(
             const marray::View<LABEL_A> arrayA,
             const marray::View<LABEL_B> arrayB

--- a/include/nifty/ground_truth/partition_comparison.hxx
+++ b/include/nifty/ground_truth/partition_comparison.hxx
@@ -25,9 +25,9 @@ public:
         typedef typename std::iterator_traits<ITERATOR_TRUTH>::value_type Label0;
         typedef typename std::iterator_traits<ITERATOR_PRED>::value_type Label1;
         typedef std::pair<Label0, Label1> Pair;
-        typedef std::map<Pair, size_t> OverlapMatrix;
-        typedef std::map<Label0, size_t> TruthSumMap;
-        typedef std::map<Label1, size_t> PredSumMap;
+        typedef std::map<Pair, std::size_t> OverlapMatrix;
+        typedef std::map<Label0, std::size_t> TruthSumMap;
+        typedef std::map<Label1, std::size_t> PredSumMap;
 
         OverlapMatrix n;
         TruthSumMap truthSum;
@@ -67,9 +67,9 @@ public:
 
         for (auto const& it : n)
         {
-            const size_t i = it.first.first;
-            const size_t j = it.first.second;
-            const size_t n_ij = it.second;
+            const std::size_t i = it.first.first;
+            const std::size_t j = it.first.second;
+            const std::size_t n_ij = it.second;
 
             trueJoins_ += n_ij * (n_ij - 1) / 2;
             falseCuts_ -= n_ij * n_ij;
@@ -82,27 +82,27 @@ public:
         trueCuts_ = pairs() - joinsInPrediction() - falseCuts_;
     }
 
-    size_t elements() const
+    std::size_t elements() const
         { return elements_; }
-    size_t pairs() const
+    std::size_t pairs() const
         { return elements_ * (elements_ - 1) / 2; }
 
-    size_t trueJoins() const
+    std::size_t trueJoins() const
         { return trueJoins_; }
-    size_t trueCuts() const
+    std::size_t trueCuts() const
         { return trueCuts_; }
-    size_t falseJoins() const
+    std::size_t falseJoins() const
         { return falseJoins_; }
-    size_t falseCuts() const
+    std::size_t falseCuts() const
         { return falseCuts_; }
 
-    size_t joinsInPrediction() const
+    std::size_t joinsInPrediction() const
         { return trueJoins_ + falseJoins_; }
-    size_t cutsInPrediction() const
+    std::size_t cutsInPrediction() const
         { return trueCuts_ + falseCuts_; }
-    size_t joinsInTruth() const
+    std::size_t joinsInTruth() const
         { return trueJoins_ + falseCuts_; }
-    size_t cutsInTruth() const
+    std::size_t cutsInTruth() const
         { return trueCuts_ + falseJoins_; }
 
     value_type recallOfCuts() const
@@ -141,11 +141,11 @@ public:
         { return static_cast<value_type>(trueJoins() + trueCuts()) / pairs(); }
 
 private:
-    size_t elements_;
-    size_t trueJoins_ { size_t() };
-    size_t trueCuts_ { size_t() };
-    size_t falseJoins_ { size_t() };
-    size_t falseCuts_ { size_t() };
+    std::size_t elements_;
+    std::size_t trueJoins_ { std::size_t() };
+    std::size_t trueCuts_ { std::size_t() };
+    std::size_t falseJoins_ { std::size_t() };
+    std::size_t falseCuts_ { std::size_t() };
 };
 
 template<class T = double>
@@ -164,7 +164,7 @@ public:
         typedef std::map<Label1, double> PVector1;
 
         // count
-        size_t N = std::distance(begin0, end0);
+        std::size_t N = std::distance(begin0, end0);
 
         PMatrix pjk;
         PVector0 pj;

--- a/include/nifty/ground_truth/seg_to_edges.hxx
+++ b/include/nifty/ground_truth/seg_to_edges.hxx
@@ -24,7 +24,7 @@ namespace ground_truth{
 
 
         CoordType shape;
-        for(size_t i=0; i<2; ++i){
+        for(std::size_t i=0; i<2; ++i){
             shape[i] = segmentation.shape(i);
         }   
 

--- a/include/nifty/hdf5/hdf5_array.hxx
+++ b/include/nifty/hdf5/hdf5_array.hxx
@@ -117,7 +117,7 @@ namespace hdf5{
             effectiveShape_.resize(dimension());
             offsetFront_.resize(dimension());
             offsetBack_.resize(dimension());
-            for(size_t d = 0; d < dimension(); ++d) {
+            for(std::size_t d = 0; d < dimension(); ++d) {
                 effectiveShape_[d] = shape_[d];
                 offsetFront_[d] = 0;
                 offsetBack_[d] = 0;
@@ -125,7 +125,7 @@ namespace hdf5{
         }
 
         int setCache(){
-            //herr_t H5Pset_cache(hid_t plist_id, int mdc_nelmts, size_t rdcc_nslots, size_t rdcc_nbytes, double rdcc_w0)
+            //herr_t H5Pset_cache(hid_t plist_id, int mdc_nelmts, std::size_t rdcc_nslots, std::size_t rdcc_nbytes, double rdcc_w0)
         }
 
         ~Hdf5Array(){
@@ -154,7 +154,7 @@ namespace hdf5{
         }
 
         void resetOffsets() {
-            for(size_t d = 0; d < dimension(); ++d) {
+            for(std::size_t d = 0; d < dimension(); ++d) {
                effectiveShape_[d] = shape_[d];
                offsetFront_[d] = 0;
                offsetBack_[d] = 0;
@@ -163,12 +163,12 @@ namespace hdf5{
 
         template<class OFFSET_ITERATOR>
         bool setOffsetFront(OFFSET_ITERATOR offsetIter) {
-            for(size_t d = 0; d < dimension(); ++d) {
+            for(std::size_t d = 0; d < dimension(); ++d) {
                offsetFront_[d] = *offsetIter;
                effectiveShape_[d] = shape_[d] - *offsetIter - offsetBack_[d];
                ++offsetIter;
             }
-            for(size_t d = 0; d < dimension(); ++d) {
+            for(std::size_t d = 0; d < dimension(); ++d) {
                 if(effectiveShape_[d] == 0 || effectiveShape_[d] > shape_[d]) {  // the shapes are uint, so negative shapes get mapped to high integers
                     std::cout << "Invalid offset setting, resetting all offsets to 0" << std::endl;
                     resetOffsets();
@@ -180,12 +180,12 @@ namespace hdf5{
 
         template<class OFFSET_ITERATOR>
         bool setOffsetBack(OFFSET_ITERATOR offsetIter) {
-            for(size_t d = 0; d < dimension(); ++d) {
+            for(std::size_t d = 0; d < dimension(); ++d) {
                offsetBack_[d] = *offsetIter;
                effectiveShape_[d] = shape_[d] - *offsetIter - offsetFront_[d];
                ++offsetIter;
             }
-            for(size_t d = 0; d < dimension(); ++d) {
+            for(std::size_t d = 0; d < dimension(); ++d) {
                 if(effectiveShape_[d] == 0 || effectiveShape_[d] > shape_[d]) {
                     std::cout << "Invalid offset setting, resetting all offsets to 0" << std::endl;
                     resetOffsets();
@@ -209,7 +209,7 @@ namespace hdf5{
                 "currently only views with last major order are supported"
             );
             std::vector<uint64_t> roiTmp(roiBeginIter, roiBeginIter+out.dimension());
-            for(size_t d = 0; d < out.dimension(); ++d)
+            for(std::size_t d = 0; d < out.dimension(); ++d)
                 roiTmp[d] += offsetFront_[d];
             this->loadHyperslab(roiTmp.begin(), roiTmp.end(), out.shapeBegin(), out);
         }
@@ -234,7 +234,7 @@ namespace hdf5{
                 "currently only views with last major order are supported"
             );
             std::vector<uint64_t> roiTmp(roiBeginIter, roiBeginIter+in.dimension());
-            for(size_t d = 0; d < in.dimension(); ++d)
+            for(std::size_t d = 0; d < in.dimension(); ++d)
                 roiTmp[d] += offsetFront_[d];
             this->saveHyperslab(roiTmp.begin(), roiTmp.end(), in.shapeBegin(), in);
         }

--- a/include/nifty/histogram/histogram.hxx
+++ b/include/nifty/histogram/histogram.hxx
@@ -14,7 +14,7 @@ namespace histogram{
         Histogram(
             const T minVal, 
             const T maxVal,
-            const size_t bincount
+            const std::size_t bincount
         )
         :   counts_(bincount),
             minVal_(minVal),
@@ -50,10 +50,10 @@ namespace histogram{
         }
 
 
-        const BincountType & operator[](const size_t i)const{
+        const BincountType & operator[](const std::size_t i)const{
             return counts_[i];
         }
-        size_t numberOfBins()const{
+        std::size_t numberOfBins()const{
             return counts_.size();
         }
         BincountType sum()const{
@@ -70,15 +70,15 @@ namespace histogram{
 
             // low and high are the same
             if(low + 0.5 >= high){
-                counts_[size_t(low)] += w;
+                counts_[std::size_t(low)] += w;
             }
             // low and high are different
             else{
                 const auto wLow  = high - b;
                 const auto wHigh = double(b) - low;
 
-                counts_[size_t(low)]  += w*wLow;
-                counts_[size_t(high)] += w*wHigh;
+                counts_[std::size_t(low)]  += w*wLow;
+                counts_[std::size_t(high)] += w*wHigh;
             }
             sum_ += w;
         }

--- a/include/nifty/ilp_backend/cplex.hxx
+++ b/include/nifty/ilp_backend/cplex.hxx
@@ -24,7 +24,7 @@ public:
 
     
 
-    void initModel(const size_t, const double*);
+    void initModel(const std::size_t, const double*);
 
     template<class Iterator>
     void setStart(Iterator);
@@ -32,7 +32,7 @@ public:
     template<class VariableIndexIterator, class CoefficientIterator>
     void addConstraint(VariableIndexIterator, VariableIndexIterator,CoefficientIterator, const double, const double);
     void optimize();
-    double label(const size_t) const;
+    double label(const std::size_t) const;
 
     static std::string name(){
         return std::string("Cplex");
@@ -43,7 +43,7 @@ public:
         OBJECTIVE_ITERATOR objectiveIter
     ){
         IloNumArray    obj(env_,nVariables_);
-        for(size_t v=0; v<nVariables_; ++v){
+        for(std::size_t v=0; v<nVariables_; ++v){
             const auto val = *objectiveIter;
 
             if(std::abs(val)<=0.00000001){
@@ -93,7 +93,7 @@ inline Cplex::Cplex(const SettingsType & settings)
 
 inline void
 Cplex::initModel(
-    const size_t numberOfVariables,
+    const std::size_t numberOfVariables,
     const double* coefficients
 ) {
     nVariables_ = numberOfVariables;
@@ -116,7 +116,7 @@ Cplex::initModel(
             //std::cout<<"create obj\n";
             IloNumArray    obj(env_,N);
 
-            for(size_t v=0; v<numberOfVariables; ++v){
+            for(std::size_t v=0; v<numberOfVariables; ++v){
                 obj[v] = coefficients[v];
             }
             obj_.setLinearCoefs(x_,obj);
@@ -225,7 +225,7 @@ Cplex::optimize() {
 
 inline double
 Cplex::label(
-    const size_t variableIndex
+    const std::size_t variableIndex
 ) const {
     if(nVariables_>=1){
         return sol_[variableIndex];

--- a/include/nifty/ilp_backend/glpk.hxx
+++ b/include/nifty/ilp_backend/glpk.hxx
@@ -19,7 +19,7 @@ public:
     Glpk(const SettingsType & settings = SettingsType());
     ~Glpk();
 
-    void initModel(const size_t, const double*);
+    void initModel(const std::size_t, const double*);
 
     template<class Iterator>
     void setStart(Iterator);
@@ -29,7 +29,7 @@ public:
                            CoefficientIterator, const double, const double);
     void optimize();
 
-    double label(const size_t) const;
+    double label(const std::size_t) const;
 
     static std::string name(){
         return std::string("Glpk");
@@ -43,7 +43,7 @@ public:
 
 private:
     SettingsType settings_;
-    size_t nVariables_;
+    std::size_t nVariables_;
 
     glp_prob * lp;
 
@@ -72,7 +72,7 @@ Glpk::~Glpk() {
 
 inline void
 Glpk::initModel(
-    const size_t numberOfVariables,
+    const std::size_t numberOfVariables,
     const double* coefficients
 ) {
 
@@ -88,7 +88,7 @@ Glpk::initModel(
     glp_add_cols(lp, nVariables_);
 
     //std::cout<<"set coeffs\n";
-    for(size_t i=0; i<nVariables_; ++i){
+    for(std::size_t i=0; i<nVariables_; ++i){
         glp_set_obj_coef(lp, i+1, coefficients[i]);
 
         // set bounds
@@ -123,7 +123,7 @@ Glpk::optimize() {
 
 inline double
 Glpk::label(
-    const size_t variableIndex
+    const std::size_t variableIndex
 ) const {
     //std::cout<<"get label\n";
     auto val = glp_mip_col_val  (lp, variableIndex+1);
@@ -155,7 +155,7 @@ Glpk::addConstraint(
     std::vector<double> coeffs(nVar+1);
 
     //indices.assign(viBegin, viEnd);
-    for(size_t i=0; i<nVar; ++i){
+    for(std::size_t i=0; i<nVar; ++i){
         indices[i+1] = viBegin[i]+1;
         coeffs[i+1] = coefficient[i];
         //std::cout<<" "<<indices[i+1]<<"\n";

--- a/include/nifty/ilp_backend/gurobi.hxx
+++ b/include/nifty/ilp_backend/gurobi.hxx
@@ -19,7 +19,7 @@ public:
     Gurobi(const SettingsType & settings = SettingsType());
     ~Gurobi();
 
-    void initModel(const size_t, const double*);
+    void initModel(const std::size_t, const double*);
 
     template<class Iterator>
     void setStart(Iterator);
@@ -29,7 +29,7 @@ public:
                            CoefficientIterator, const double, const double);
     void optimize();
 
-    double label(const size_t) const;
+    double label(const std::size_t) const;
 
     static std::string name(){
         return std::string("Gurobi");
@@ -49,7 +49,7 @@ private:
     GRBModel* gurobiModel_;
     GRBVar* gurobiVariables_;
     GRBLinExpr gurobiObjective_;
-    size_t nVariables_;
+    std::size_t nVariables_;
 };
 
 inline Gurobi::Gurobi(const SettingsType & settings)
@@ -76,7 +76,7 @@ Gurobi::~Gurobi() {
 
 inline void
 Gurobi::initModel(
-    const size_t numberOfVariables,
+    const std::size_t numberOfVariables,
     const double* coefficients
 ) {
     nVariables_ = numberOfVariables;
@@ -163,7 +163,7 @@ Gurobi::optimize() {
 
 inline double
 Gurobi::label(
-    const size_t variableIndex
+    const std::size_t variableIndex
 ) const {
     return gurobiVariables_[variableIndex].get(GRB_DoubleAttr_X);
 }
@@ -181,7 +181,7 @@ Gurobi::addConstraint(
 ) {
     GRBLinExpr expression;
     for(; viBegin != viEnd; ++viBegin, ++coefficient) {
-        expression += (*coefficient) * gurobiVariables_[static_cast<size_t>(*viBegin)];
+        expression += (*coefficient) * gurobiVariables_[static_cast<std::size_t>(*viBegin)];
     }
     if(lowerBound == upperBound) {
         GRBLinExpr exact(lowerBound);
@@ -204,7 +204,7 @@ inline void
 Gurobi::setStart(
     Iterator valueIterator
 ) {
-    for(size_t j = 0; j < nVariables_; ++j, ++valueIterator) {
+    for(std::size_t j = 0; j < nVariables_; ++j, ++valueIterator) {
         gurobiVariables_[j].set(GRB_DoubleAttr_Start, static_cast<double>(*valueIterator));
     }
 }

--- a/include/nifty/ilp_backend/ilp_backend.hxx
+++ b/include/nifty/ilp_backend/ilp_backend.hxx
@@ -32,8 +32,8 @@ namespace ilp_backend{
         PreSolver preSolver{PRE_SOLVER_DEFAULT};
         LPSolver  lpSolver{LP_SOLVER_DEFAULT};
 
-        size_t numberOfThreads{1};
-        size_t verbosity{0};
+        std::size_t numberOfThreads{1};
+        std::size_t verbosity{0};
 
     };  
 

--- a/include/nifty/malis/malis.hxx
+++ b/include/nifty/malis/malis.hxx
@@ -15,8 +15,8 @@ namespace malis{
 template<unsigned DIM, typename DATA_TYPE, typename LABEL_TYPE>
 void compute_malis_gradient(const marray::View<DATA_TYPE> & affinities,
         const marray::View<LABEL_TYPE> & groundtruth,
-        marray::View<size_t> & positiveGradients,
-        marray::View<size_t> & negativeGradients) { // TODO which dtype / output format for the gradients ?
+        marray::View<std::size_t> & positiveGradients,
+        marray::View<std::size_t> & negativeGradients) { // TODO which dtype / output format for the gradients ?
     
     typedef nifty::array::StaticArray<int64_t,DIM>   Coord;
     typedef nifty::array::StaticArray<int64_t,DIM+1> AffinityCoord;
@@ -41,7 +41,7 @@ void compute_malis_gradient(const marray::View<DATA_TYPE> & affinities,
         pixelShape[d] = groundtruth.shape(d);
     // init union find and overlaps
     ufd::Ufd<LabelType> sets(numberOfNodes);
-    std::vector<std::map<LabelType,size_t>> overlaps(numberOfNodes);
+    std::vector<std::map<LabelType,std::size_t>> overlaps(numberOfNodes);
     int pixelIndex;
     tools::forEachCoordinate(pixelShape, [&](Coord coord) {
         auto gtId = groundtruth(coord.asStdArray());
@@ -60,27 +60,27 @@ void compute_malis_gradient(const marray::View<DATA_TYPE> & affinities,
     for(int d = 0; d < DIM+1; ++d)
         affinityShape[d] = affinities.shape(d);
     // get a flattened view to the marray
-    size_t flatShape[] = {affinities.size()};
+    std::size_t flatShape[] = {affinities.size()};
     auto flatView = affinities.reshapedView(flatShape, flatShape+1);
     // initialize the pqueu as [0,1,2,3,...,numberOfEdges]
-    std::vector<size_t> pqueue(numberOfEdges);
+    std::vector<std::size_t> pqueue(numberOfEdges);
     std::iota(pqueue.begin(), pqueue.end(), 0);
     // sort pqueue in increasing order
     std::sort(pqueue.begin(), pqueue.end(),
-            [&flatView](const size_t ind1, const size_t ind2){
+            [&flatView](const std::size_t ind1, const std::size_t ind2){
         return (flatView(ind1)>flatView(ind2));         
     });
 
     // run kruskals
-    size_t edgeIndex, channel;
+    std::size_t edgeIndex, channel;
     LabelType setU, setV;
-    size_t nPair = 0;
+    std::size_t nPair = 0;
     Coord gtCoordU, gtCoordV;
     AffinityCoord affCoord;
-    typename std::map<LabelType,size_t>::iterator itU, itV;
+    typename std::map<LabelType,std::size_t>::iterator itU, itV;
 
     // iterate over the pqueue
-    for(size_t i = 0; i < pqueue.size(); ++i) {
+    for(std::size_t i = 0; i < pqueue.size(); ++i) {
         
         edgeIndex  = pqueue[i];
         

--- a/include/nifty/marray/andres/marray-hdf5.hxx
+++ b/include/nifty/marray/andres/marray-hdf5.hxx
@@ -436,7 +436,7 @@ void save(
 {
     std::size_t shape[] = {in.size()};
     andres::Marray<T> mvector(shape, shape + 1);
-    for(size_t j=0; j<in.size(); ++j) {
+    for(std::size_t j=0; j<in.size(); ++j) {
         mvector(j) = in[j];
     }
     save(groupHandle, datasetName, mvector);

--- a/include/nifty/math/math.hxx
+++ b/include/nifty/math/math.hxx
@@ -10,7 +10,7 @@
 namespace nifty{
 namespace math{
     
-    template<class T0, class T1, size_t N>
+    template<class T0, class T1, std::size_t N>
     typename nifty::math::PromoteTraits<T0,T1>::RealPromoteType 
     euclideanDistance(
         const nifty::array::StaticArray<T0, N> & a,
@@ -20,7 +20,7 @@ namespace math{
 
         auto d = Numerics<T0T1>::zero();
 
-        for(size_t i=0; i<N; ++i){
+        for(std::size_t i=0; i<N; ++i){
 
             const auto dist = T0T1(a[i])-T0T1(b[i]);
             d += dist*dist;

--- a/include/nifty/parallel/threadpool.hxx
+++ b/include/nifty/parallel/threadpool.hxx
@@ -87,7 +87,7 @@ class ParallelOptions
 
   private:
         // helper function to compute the actual number of threads
-    static size_t actualNumThreads(const int userNThreads)
+    static std::size_t actualNumThreads(const int userNThreads)
     {
         #ifdef NIFTY_NO_PARALLELISM
             return 0;
@@ -182,7 +182,7 @@ class ThreadPool
     /**
      * Return the number of worker threads.
      */
-    size_t nThreads() const
+    std::size_t nThreads() const
     {
         return workers.size();
     }
@@ -208,8 +208,8 @@ private:
 
 inline void ThreadPool::init(const ParallelOptions & options)
 {
-    const size_t actualNThreads = options.getNumThreads();
-    for(size_t ti = 0; ti<actualNThreads; ++ti)
+    const std::size_t actualNThreads = options.getNumThreads();
+    for(std::size_t ti = 0; ti<actualNThreads; ++ti)
     {
         workers.emplace_back(
             [ti,this]
@@ -349,14 +349,14 @@ inline void parallel_foreach_impl(
     std::vector<std::future<void> > futures;
     for( ;iter<end; iter+=chunkedWorkPerThread)
     {
-        const size_t lc = std::min(workload, chunkedWorkPerThread);
+        const std::size_t lc = std::min(workload, chunkedWorkPerThread);
         workload-=lc;
         futures.emplace_back(
             pool.enqueue(
                 [&f, iter, lc]
                 (int id)
                 {
-                    for(size_t i=0; i<lc; ++i)
+                    for(std::size_t i=0; i<lc; ++i)
                         f(id, iter[i]);
                 }
             )
@@ -390,7 +390,7 @@ inline void parallel_foreach_impl(
     std::vector<std::future<void> > futures;
     for(;;)
     {
-        const size_t lc = std::min(chunkedWorkPerThread, workload);
+        const std::size_t lc = std::min(chunkedWorkPerThread, workload);
         workload -= lc;
         futures.emplace_back(
             pool.enqueue(
@@ -398,14 +398,14 @@ inline void parallel_foreach_impl(
                 (int id)
                 {
                     auto iterCopy = iter;
-                    for(size_t i=0; i<lc; ++i){
+                    for(std::size_t i=0; i<lc; ++i){
                         f(id, *iterCopy);
                         ++iterCopy;
                     }
                 }
             )
         );
-        for (size_t i = 0; i < lc; ++i)
+        for (std::size_t i = 0; i < lc; ++i)
         {
             ++iter;
             if (iter == end)
@@ -433,7 +433,7 @@ inline void parallel_foreach_impl(
     F && f,
     std::input_iterator_tag
 ){
-    size_t num_items = 0;
+    std::size_t num_items = 0;
     std::vector<std::future<void> > futures;
     for (; iter != end; ++iter)
     {
@@ -461,7 +461,7 @@ inline void parallel_foreach_single_thread(
     F && f,
     const std::ptrdiff_t nItems = 0
 ){
-    size_t n = 0;
+    std::size_t n = 0;
     for (; begin != end; ++begin)
     {
         f(0, *begin);
@@ -541,8 +541,8 @@ inline void parallel_foreach_single_thread(
 
     int main()
     {
-        size_t const n_threads = 4;
-        size_t const n = 2000;
+        std::size_t const n_threads = 4;
+        std::size_t const n = 2000;
         vector<int> input(n);
 
         auto iter = input.begin(),
@@ -558,7 +558,7 @@ inline void parallel_foreach_single_thread(
         parallel_foreach(n_threads, iter, end,
             // the functor to be executed, defined as a lambda function
             // (first argument: thread ID, second argument: result of *iter)
-            [&results](size_t thread_id, int items)
+            [&results](std::size_t thread_id, int items)
             {
                 results[thread_id] += items;
             }

--- a/include/nifty/python/graph/agglo/export_agglomerative_clustering.hxx
+++ b/include/nifty/python/graph/agglo/export_agglomerative_clustering.hxx
@@ -139,7 +139,7 @@ namespace agglo{
                 const AgglomerativeClusteringType * self
             ){
                 const auto graph = self->graph();
-                nifty::marray::PyView<uint64_t> out({size_t(graph.nodeIdUpperBound()+1)});
+                nifty::marray::PyView<uint64_t> out({std::size_t(graph.nodeIdUpperBound()+1)});
                 {
                     py::gil_scoped_release allowThreds;
                     self->result(out);

--- a/include/nifty/python/graph/opt/common/py_proposal_generator_factory_base.hxx
+++ b/include/nifty/python/graph/opt/common/py_proposal_generator_factory_base.hxx
@@ -25,7 +25,7 @@ public:
     typedef typename ObjectiveType::GraphType GraphType;
     typedef ProposalGeneratorBase<ObjectiveType> ProposalGeneratorBaseType;
     /* Trampoline (need one for each virtual function) */
-    std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective, const size_t numberOfThreads) {
+    std::shared_ptr<ProposalGeneratorBaseType> createShared(const ObjectiveType & objective, const std::size_t numberOfThreads) {
         PYBIND11_OVERLOAD_PURE(
             std::shared_ptr<ProposalGeneratorBaseType>,     /* Return type */
             ProposalGeneratorFactoryBase<ObjectiveType>,        /* Parent class */
@@ -33,7 +33,7 @@ public:
             objective, numberOfThreads                      /* Argument(s) */
         );
     }
-    ProposalGeneratorBaseType * create(const ObjectiveType & objective, const size_t numberOfThreads) {
+    ProposalGeneratorBaseType * create(const ObjectiveType & objective, const std::size_t numberOfThreads) {
         PYBIND11_OVERLOAD_PURE(
             ProposalGeneratorBaseType* ,                    /* Return type */
             ProposalGeneratorFactoryBase<ObjectiveType>,        /* Parent class */

--- a/include/nifty/python/graph/opt/lifted_multicut/py_proposal_generator_factory_base.hxx
+++ b/include/nifty/python/graph/opt/lifted_multicut/py_proposal_generator_factory_base.hxx
@@ -22,7 +22,7 @@ public:
     typedef OBJECTIVE Objective;
     typedef ProposalGeneratorBase<Objective> ProposalGeneratorBaseType;
     /* Trampoline (need one for each virtual function) */
-    std::shared_ptr<ProposalGeneratorBaseType> createShared(const Objective & objective, const size_t numberOfThreads) {
+    std::shared_ptr<ProposalGeneratorBaseType> createShared(const Objective & objective, const std::size_t numberOfThreads) {
         PYBIND11_OVERLOAD_PURE(
             std::shared_ptr<ProposalGeneratorBaseType>,     /* Return type */
             ProposalGeneratorFactoryBase<Objective>,        /* Parent class */
@@ -30,7 +30,7 @@ public:
             objective, numberOfThreads                                           /* Argument(s) */
         );
     }
-    ProposalGeneratorBaseType * create(const Objective & objective, const size_t numberOfThreads) {
+    ProposalGeneratorBaseType * create(const Objective & objective, const std::size_t numberOfThreads) {
         PYBIND11_OVERLOAD_PURE(
             ProposalGeneratorBaseType* ,                    /* Return type */
             ProposalGeneratorFactoryBase<Objective>,        /* Parent class */

--- a/include/nifty/python/graph/undirected_grid_graph.hxx
+++ b/include/nifty/python/graph/undirected_grid_graph.hxx
@@ -11,7 +11,7 @@ namespace graph{
 
 
     template<
-        size_t DIM,
+        std::size_t DIM,
         bool SIMPLE_NH
     >
     struct GraphName<UndirectedGridGraph<DIM, SIMPLE_NH>>{

--- a/include/nifty/tools/blocking.hxx
+++ b/include/nifty/tools/blocking.hxx
@@ -111,7 +111,7 @@ namespace tools{
             blocksPerAxisStrides_(),
             numberOfBlocks_(1){
         
-            for(size_t d=0; d<DIM; ++d){
+            for(std::size_t d=0; d<DIM; ++d){
                 const auto dimSize = roiEnd_[d] - (roiBegin_[d] - blockShift_[d]);
                 const auto bs = blockShape_[d];
                 const auto bpa =  dimSize / bs + int((dimSize % bs) != 0);
@@ -145,7 +145,7 @@ namespace tools{
             return blocksPerAxis_;  
         }
         
-        const size_t numberOfBlocks()const{
+        const std::size_t numberOfBlocks()const{
             return numberOfBlocks_;
         }
 
@@ -198,7 +198,7 @@ namespace tools{
 
             idsOut.clear();
 
-            for(size_t blockId = 0; blockId < numberOfBlocks(); ++blockId) {
+            for(std::size_t blockId = 0; blockId < numberOfBlocks(); ++blockId) {
 
                 // get coordinates of the current bock
                 const auto & block = getBlockWithHalo(blockId, blockHalo).outerBlock();
@@ -237,7 +237,7 @@ namespace tools{
                 return (value >= min) && (value <= max);
             };
 
-            for(size_t blockId = 0; blockId < numberOfBlocks(); ++blockId) {
+            for(std::size_t blockId = 0; blockId < numberOfBlocks(); ++blockId) {
 
                 // get coordinates of the current bock
                 const auto & block = getBlockWithHalo(blockId, blockHalo).outerBlock();
@@ -350,7 +350,7 @@ namespace tools{
             //
             idsOut.clear();
 
-            for(size_t blockId = 0; blockId < numberOfBlocks(); ++blockId) {
+            for(std::size_t blockId = 0; blockId < numberOfBlocks(); ++blockId) {
                 const auto & block = getBlockWithHalo(blockId, blockHalo).outerBlock();
                 const auto & begin = block.begin();
                 const auto & end   = block.end();
@@ -405,7 +405,7 @@ namespace tools{
 
         VectorType blocksPerAxis_;
         VectorType blocksPerAxisStrides_;
-        size_t numberOfBlocks_;
+        std::size_t numberOfBlocks_;
     };
 
 

--- a/include/nifty/tools/changable_priority_queue.hxx
+++ b/include/nifty/tools/changable_priority_queue.hxx
@@ -27,7 +27,7 @@ public:
 
 
     /// Create an empty ChangeablePriorityQueue which can contain atmost maxSize elements
-    ChangeablePriorityQueue(const size_t maxSize)  
+    ChangeablePriorityQueue(const std::size_t maxSize)  
     : maxSize_(maxSize),
       currentSize_(0),
       heap_(maxSize_+1),
@@ -185,8 +185,8 @@ private:
     }
  
 
-    size_t maxSize_;
-    size_t currentSize_;
+    std::size_t maxSize_;
+    std::size_t currentSize_;
     std::vector<int> heap_;
     std::vector<int> indices_;
     std::vector<T>   priorities_;

--- a/include/nifty/tools/edge_mapping.hxx
+++ b/include/nifty/tools/edge_mapping.hxx
@@ -20,7 +20,7 @@ public:
     typedef std::pair<NodeType, NodeType> UvType;
     typedef std::vector<UvType> UvVectorType;
 
-    EdgeMapping(const size_t numberOfEdges, const int nThreads=-1)
+    EdgeMapping(const std::size_t numberOfEdges, const int nThreads=-1)
         : oldToNewEdges_(numberOfEdges), newUvIds_(), threadpool_(nThreads)
     {}
 
@@ -34,7 +34,7 @@ public:
 
     void getNewEdgeIds(const std::vector<EdgeType> & edgeIds, std::vector<EdgeType> & newEdgeIds) const;
 
-    size_t numberOfNewEdges() const
+    std::size_t numberOfNewEdges() const
     {return newUvIds_.size();}
 
 private:
@@ -111,7 +111,7 @@ void EdgeMapping<EDGE_TYPE, NODE_TYPE>::initializeMapping(const marray::View<Edg
 
     //// via set TODO unordered
     std::set<UvType> uvNewTmp;
-    for(size_t t = 0; t < threadpool_.nThreads(); ++t) {
+    for(std::size_t t = 0; t < threadpool_.nThreads(); ++t) {
         const auto & thisSet = threadSets[t];
         uvNewTmp.insert(thisSet.begin(), thisSet.end());
     }

--- a/include/nifty/tools/for_each_block.hxx
+++ b/include/nifty/tools/for_each_block.hxx
@@ -12,7 +12,7 @@ namespace tools{
 
     
     
-    template<size_t DIM, class SHAPE_T, class BLOCK_SHAPE_T, class F>
+    template<std::size_t DIM, class SHAPE_T, class BLOCK_SHAPE_T, class F>
     void parallelForEachBlock(
         parallel::ThreadPool & threadpool,
         const array::StaticArray<SHAPE_T, DIM> & shape,
@@ -39,7 +39,7 @@ namespace tools{
     }
 
 
-    template<size_t DIM, class SHAPE_T, class BLOCK_SHAPE_T, class OVERLAP_SHAPE_T, class F>
+    template<std::size_t DIM, class SHAPE_T, class BLOCK_SHAPE_T, class OVERLAP_SHAPE_T, class F>
     void parallelForEachBlockWithOverlap(
         parallel::ThreadPool & threadpool,
         const array::StaticArray<SHAPE_T, DIM> &    shape,

--- a/include/nifty/tools/for_each_coordinate.hxx
+++ b/include/nifty/tools/for_each_coordinate.hxx
@@ -182,7 +182,7 @@ namespace tools{
         }
     }
 
-    template<class SHAPE_T, size_t DIMENSIONS, class F>
+    template<class SHAPE_T, std::size_t DIMENSIONS, class F>
     void forEachCoordinate(
         const array::StaticArray<SHAPE_T, DIMENSIONS> & shape,
         F && f,
@@ -191,7 +191,7 @@ namespace tools{
         forEachCoordinateImpl(shape, f, firstCoordinateMajorOrder);
     }
 
-    template<class SHAPE_T, size_t DIMENSIONS, class F>
+    template<class SHAPE_T, std::size_t DIMENSIONS, class F>
     void forEachCoordinate(
         const array::StaticArray<SHAPE_T, DIMENSIONS> & shapeBegin,
         const array::StaticArray<SHAPE_T, DIMENSIONS> & shapeEnd,
@@ -204,7 +204,7 @@ namespace tools{
 
 
 
-    template<class SHAPE_T, size_t DIM, class F>
+    template<class SHAPE_T, std::size_t DIM, class F>
     void parallelForEachCoordinate(
         nifty::parallel::ThreadPool & threadpool,                   
         const array::StaticArray<SHAPE_T, DIM> & shape,

--- a/include/nifty/tools/nodes_to_blocks.hxx
+++ b/include/nifty/tools/nodes_to_blocks.hxx
@@ -30,7 +30,7 @@ namespace tools{
         out.resize(nBlocks);
 
         const auto & shape = segmentation.shape();
-        Coord sliceShape({1L,int64_t(shape[1]),int64_t(shape[2])});
+        Coord sliceShape({1LL,int64_t(shape[1]),int64_t(shape[2])});
 
         // thread data
         LabelsStorage labelsStorage(threadpool, sliceShape, nThreads);
@@ -45,7 +45,7 @@ namespace tools{
             auto & threadUniques = threadData[tid];
 
             // get subblocks in this slice
-            Coord sliceBegin({sliceId,0L,0L});
+            Coord sliceBegin({sliceId,0LL,0LL});
             std::vector<uint64_t> subBlocks;
             blocking.getBlockIdsInSlice(sliceId, internalHalo, subBlocks);
             

--- a/include/nifty/tools/nodes_to_blocks.hxx
+++ b/include/nifty/tools/nodes_to_blocks.hxx
@@ -30,7 +30,7 @@ namespace tools{
         out.resize(nBlocks);
 
         const auto & shape = segmentation.shape();
-        Coord sliceShape({1LL,int64_t(shape[1]),int64_t(shape[2])});
+        Coord sliceShape({int64_t(1),int64_t(shape[1]),int64_t(shape[2])});
 
         // thread data
         LabelsStorage labelsStorage(threadpool, sliceShape, nThreads);
@@ -45,7 +45,7 @@ namespace tools{
             auto & threadUniques = threadData[tid];
 
             // get subblocks in this slice
-            Coord sliceBegin({sliceId,0LL,0LL});
+            Coord sliceBegin({sliceId,int64_t(0),int64_t(0)});
             std::vector<uint64_t> subBlocks;
             blocking.getBlockIdsInSlice(sliceId, internalHalo, subBlocks);
             

--- a/include/nifty/tools/nodes_to_blocks.hxx
+++ b/include/nifty/tools/nodes_to_blocks.hxx
@@ -26,7 +26,7 @@ namespace tools{
         nifty::parallel::ParallelOptions pOpts(nThreads);
         nifty::parallel::ThreadPool threadpool(pOpts);
         
-        size_t nBlocks = blocking.numberOfBlocks();
+        std::size_t nBlocks = blocking.numberOfBlocks();
         out.resize(nBlocks);
 
         const auto & shape = segmentation.shape();
@@ -61,7 +61,7 @@ namespace tools{
                 const auto block = blocking.getBlockWithHalo(blockId, internalHalo).outerBlock();
                 const auto & blockBegin3d = block.begin();
                 const auto & blockShape3d = block.shape();
-                size_t expSize = 1;
+                std::size_t expSize = 1;
                 for(int d = 0; d < 2; ++d) {
                     blockBegin[d] = blockBegin3d[d+1];
                     blockShape[d] = blockShape3d[d+1];

--- a/src/python/lib/cgp/bounds.cxx
+++ b/src/python/lib/cgp/bounds.cxx
@@ -22,8 +22,8 @@ namespace cgp{
 
 
     template<
-        size_t DIM, 
-        size_t CELL_TYPE,
+        std::size_t DIM, 
+        std::size_t CELL_TYPE,
         class CLS
     >
     void exportCellBoundsT(py::module & m, py::class_<CLS> & pyCls) {
@@ -60,12 +60,12 @@ namespace cgp{
             auto clsVec = py::class_<Cells0BoundsVector2D>(m, clsNameVec.c_str());
             clsVec
                 .def("__array__",[](const Cells0BoundsVector2D & self){
-                    nifty::marray::PyView<uint32_t> ret({size_t(self.size()),size_t(4)});
-                    for(size_t ci=0 ;ci<self.size(); ++ci){
-                        for(size_t i=0; i<self[ci].size(); ++i){
+                    nifty::marray::PyView<uint32_t> ret({std::size_t(self.size()),std::size_t(4)});
+                    for(std::size_t ci=0 ;ci<self.size(); ++ci){
+                        for(std::size_t i=0; i<self[ci].size(); ++i){
                             ret(ci,i) = self[ci][i];
                         }
-                        for(size_t i=self[ci].size(); i<4; ++i){
+                        for(std::size_t i=self[ci].size(); i<4; ++i){
                             ret(ci,i) = 0;
                         }
                     }
@@ -88,7 +88,7 @@ namespace cgp{
             auto clsVec = py::class_<Cell1BoundsVector2D>(m, clsNameVec.c_str());
             clsVec
                 .def("__array__",[](const Cell1BoundsVector2D & self){
-                    nifty::marray::PyView<uint32_t> ret({size_t(self.size()),size_t(2)});
+                    nifty::marray::PyView<uint32_t> ret({std::size_t(self.size()),std::size_t(2)});
                     for(uint32_t ci=0 ;ci<self.size(); ++ci){
                         ret(ci,0) = self[ci][0];
                         ret(ci,1) = self[ci][1];
@@ -117,7 +117,7 @@ namespace cgp{
             clsVec
                 .def(py::init<const CellBoundsVector<2,0 > &>())
                 .def("__array__",[](const Cell1BoundedByVector2D & self){
-                    nifty::marray::PyView<uint32_t> ret({size_t(self.size()),size_t(2)});
+                    nifty::marray::PyView<uint32_t> ret({std::size_t(self.size()),std::size_t(2)});
                     for(uint32_t ci=0 ;ci<self.size(); ++ci){
                         const auto & b = self[ci];
                         ret(ci,0) = b[0];
@@ -125,7 +125,7 @@ namespace cgp{
                     }
                     return ret;
                 })
-                .def("cellsWithCertainBoundedBySize",[](const Cell1BoundedByVector2D & self,const size_t size){
+                .def("cellsWithCertainBoundedBySize",[](const Cell1BoundedByVector2D & self,const std::size_t size){
 
                     std::vector<uint32_t>  cell1Labels;
 
@@ -137,7 +137,7 @@ namespace cgp{
                     }
 
 
-                    nifty::marray::PyView<uint32_t> ret({size_t(cell1Labels.size())});
+                    nifty::marray::PyView<uint32_t> ret({std::size_t(cell1Labels.size())});
                     for(auto i=0; i<ret.size(); ++i){
                         ret[i] = cell1Labels[i];
                     }
@@ -163,7 +163,7 @@ namespace cgp{
             clsVec
                 .def(py::init<const CellBoundsVector<2,1 > &>())
                 //.def("__array__",[](const Cell2BoundedByVector2D & self){
-                //    nifty::marray::PyView<uint32_t> ret({size_t(self.size()),size_t(2)});
+                //    nifty::marray::PyView<uint32_t> ret({std::size_t(self.size()),std::size_t(2)});
                 //    for(uint32_t ci=0 ;ci<self.size(); ++ci){
                 //        ret(ci,0) = self[ci][0];
                 //        ret(ci,1) = self[ci][1];

--- a/src/python/lib/cgp/features.cxx
+++ b/src/python/lib/cgp/features.cxx
@@ -44,8 +44,8 @@ namespace cgp{
                     const CellGeometryVector<2,1> &  cell1GeometryVector,
                     const CellBoundedByVector<2,1> & cell1BoundedByVector
                 ){
-                    const auto nFeatures = size_t(op.numberOfFeatures());
-                    const auto nCells1   = size_t(cell1GeometryVector.size());
+                    const auto nFeatures = std::size_t(op.numberOfFeatures());
+                    const auto nCells1   = std::size_t(cell1GeometryVector.size());
 
                     nifty::marray::PyView<float> out({nCells1, nFeatures});
 
@@ -66,16 +66,16 @@ namespace cgp{
 
             pyCls
             .def(
-                py::init< const std::vector<size_t> &>(),
-                py::arg("dists")  =  std::vector<size_t>({size_t(3),size_t(5),size_t(7)})
+                py::init< const std::vector<std::size_t> &>(),
+                py::arg("dists")  =  std::vector<std::size_t>({std::size_t(3),std::size_t(5),std::size_t(7)})
             )
             .def("__call__",
                 [](
                     const Op & op,
                     const CellGeometryVector<2,1> &  cell1GeometryVector
                 ){
-                    const auto nFeatures = size_t(op.numberOfFeatures());
-                    const auto nCells1   = size_t(cell1GeometryVector.size());
+                    const auto nFeatures = std::size_t(op.numberOfFeatures());
+                    const auto nCells1   = std::size_t(cell1GeometryVector.size());
 
                     nifty::marray::PyView<float> out({nCells1, nFeatures});
 
@@ -102,8 +102,8 @@ namespace cgp{
                     const CellGeometryVector<2,2>   & cell2GeometryVector,
                     const CellBoundsVector<2,1>     & cell1BoundsVector
                 ){
-                    const auto nFeatures = size_t(op.numberOfFeatures());
-                    const auto nCells1   = size_t(cell1GeometryVector.size());
+                    const auto nFeatures = std::size_t(op.numberOfFeatures());
+                    const auto nCells1   = std::size_t(cell1GeometryVector.size());
 
                     nifty::marray::PyView<float> out({nCells1, nFeatures});
 
@@ -137,8 +137,8 @@ namespace cgp{
                     const CellBoundedByVector<2,1>  & cell1BoundedByVector,
                     const CellBoundedByVector<2,2>  & cell2BoundedByVector
                 ){
-                    const auto nFeatures = size_t(op.numberOfFeatures());
-                    const auto nCells1   = size_t(cell1BoundsVector.size());
+                    const auto nFeatures = std::size_t(op.numberOfFeatures());
+                    const auto nCells1   = std::size_t(cell1BoundsVector.size());
 
                     nifty::marray::PyView<float> out({nCells1, nFeatures});
 

--- a/src/python/lib/cgp/geometry.cxx
+++ b/src/python/lib/cgp/geometry.cxx
@@ -16,8 +16,8 @@ namespace cgp{
     
 
     template<
-        size_t DIM, 
-        size_t CELL_TYPE,
+        std::size_t DIM, 
+        std::size_t CELL_TYPE,
         class CLS
     >
     void exportCellGeometryT(py::module & m, py::class_<CLS> & pyCls) {
@@ -31,10 +31,10 @@ namespace cgp{
             })
             .def("centerOfMass",&CLS::centerOfMass)
             .def("__array__", [](const CLS & self){
-                nifty::marray::PyView<uint32_t> out({size_t(self.size()),size_t(DIM)});
-                for(size_t i=0; i<self.size(); ++i){
+                nifty::marray::PyView<uint32_t> out({std::size_t(self.size()),std::size_t(DIM)});
+                for(std::size_t i=0; i<self.size(); ++i){
                     const auto & coord = self[i];
-                    for(size_t d=0; d<DIM; ++d){
+                    for(std::size_t d=0; d<DIM; ++d){
                         out(i, d) = coord[d];
                     }
                 }

--- a/src/python/lib/cgp/topological_grid.cxx
+++ b/src/python/lib/cgp/topological_grid.cxx
@@ -13,7 +13,7 @@ namespace py = pybind11;
 namespace nifty{
 namespace cgp{
 
-    template<size_t DIM>
+    template<std::size_t DIM>
     void exportTopologicalGridT(py::module & m) {
 
         typedef TopologicalGrid<DIM> TopologicalGrid;
@@ -42,7 +42,7 @@ namespace cgp{
         ;
     }
 
-    template<size_t DIM>
+    template<std::size_t DIM>
     void exportFilledTopologicalGridT(py::module & m) {
 
         typedef TopologicalGrid<DIM> TopologicalGrid;

--- a/src/python/lib/converter.hxx
+++ b/src/python/lib/converter.hxx
@@ -50,8 +50,8 @@ namespace marray
             auto info = py_array.request();
             Type *ptr = (Type *)info.ptr;
 
-            std::vector<size_t> strides(info.strides.begin(),info.strides.end());
-            for(size_t i=0; i<strides.size(); ++i){
+            std::vector<std::size_t> strides(info.strides.begin(),info.strides.end());
+            for(std::size_t i=0; i<strides.size(); ++i){
                 strides[i] /= sizeof(Type);
             }
             this->assign( info.shape.begin(), info.shape.end(), strides.begin(), ptr, FirstMajorOrder);
@@ -69,14 +69,14 @@ namespace marray
         }
         template <class ShapeIterator> PyView(ShapeIterator begin, ShapeIterator end)
         {
-            std::vector<size_t> shape, strides;
+            std::vector<std::size_t> shape, strides;
 
             for (auto i = begin; i != end; ++i)
                 shape.push_back(*i);
 
-            for (size_t i = 0; i < shape.size(); ++i) {
-                size_t stride = sizeof(Type);
-                for (size_t j = i + 1; j < shape.size(); ++j)
+            for (std::size_t i = 0; i < shape.size(); ++i) {
+                std::size_t stride = sizeof(Type);
+                for (std::size_t j = i + 1; j < shape.size(); ++j)
                     stride *= shape[j];
                 strides.push_back(stride);
             }
@@ -86,7 +86,7 @@ namespace marray
             pybind11::buffer_info info = py_array.request();
             Type *ptr = (Type *)info.ptr;
 
-            for (size_t i = 0; i < shape.size(); ++i) {
+            for (std::size_t i = 0; i < shape.size(); ++i) {
                 strides[i] /= sizeof(Type);
             }
             this->assign(begin, end, strides.begin(), ptr, LastMajorOrder);
@@ -182,8 +182,8 @@ namespace pybind11
 namespace nifty{
 
     template<class T>
-    std::vector<size_t> toSizeT(std::initializer_list<T> l){
-        return std::vector<size_t>(l.begin(),l.end());
+    std::vector<std::size_t> toSizeT(std::initializer_list<T> l){
+        return std::vector<std::size_t>(l.begin(),l.end());
     }
 
 

--- a/src/python/lib/graph/connected_components.cxx
+++ b/src/python/lib/graph/connected_components.cxx
@@ -131,7 +131,7 @@ namespace graph{
             ComponentsType & self
         ){
             const auto & g = self.graph();
-            const size_t size = g.nodeIdUpperBound()+1;
+            const std::size_t size = g.nodeIdUpperBound()+1;
             nifty::marray::PyView<uint64_t> ccLabels({size});
             for(const auto node : g.nodes()){
                 ccLabels[node] = self.componentLabel(node);

--- a/src/python/lib/graph/export_shortest_path_dijkstra.cxx
+++ b/src/python/lib/graph/export_shortest_path_dijkstra.cxx
@@ -80,7 +80,7 @@ namespace graph{
             std::vector<Path> & paths) {
         paths.clear();
         paths.resize(targets.size());
-        for(size_t ii = 0; ii < targets.size(); ++ii) {
+        for(std::size_t ii = 0; ii < targets.size(); ++ii) {
             pathsFromPredecessors(sp, source, targets[ii], paths[ii]);
         }
     }
@@ -93,7 +93,7 @@ namespace graph{
             std::vector<Path> & paths) {
         paths.clear();
         paths.resize(targets.size());
-        for(size_t ii = 0; ii < targets.size(); ++ii) {
+        for(std::size_t ii = 0; ii < targets.size(); ++ii) {
             edgePathsFromPredecessors(sp, source, targets[ii], paths[ii]);
         }
     }

--- a/src/python/lib/graph/long_range_adjacency/long_range_adjacency.cxx
+++ b/src/python/lib/graph/long_range_adjacency/long_range_adjacency.cxx
@@ -45,17 +45,17 @@ namespace graph{
         auto clsT = py::class_<AdjacencyType, BaseGraph>(module, clsName.c_str());
         clsT
             .def("numberOfEdgesInSlice", [](const AdjacencyType & self){
-                size_t nSlices = self.shape(0);
-                std::vector<size_t> out(nSlices);
-                for(size_t slice = 0; slice < nSlices; ++slice){
+                std::size_t nSlices = self.shape(0);
+                std::vector<std::size_t> out(nSlices);
+                for(std::size_t slice = 0; slice < nSlices; ++slice){
                     out[slice] = self.numberOfEdgesInSlice(slice);
                 }
                 return out;
             })
             .def("edgeOffset", [](const AdjacencyType & self){
-                size_t nSlices = self.shape(0);
-                std::vector<size_t> out(nSlices);
-                for(size_t slice = 0; slice < nSlices; ++slice){
+                std::size_t nSlices = self.shape(0);
+                std::vector<std::size_t> out(nSlices);
+                for(std::size_t slice = 0; slice < nSlices; ++slice){
                     out[slice] = self.edgeOffset(slice);
                 }
                 return out;
@@ -73,8 +73,8 @@ namespace graph{
         module.def(facName.c_str(),
             [](
                Labels labels,
-               const size_t range,
-               const size_t numberOfLabels,
+               const std::size_t range,
+               const std::size_t numberOfLabels,
                const bool ignoreLabel,
                const int numberOfThreads
             ){

--- a/src/python/lib/graph/long_range_adjacency/long_range_features.cxx
+++ b/src/python/lib/graph/long_range_adjacency/long_range_features.cxx
@@ -33,7 +33,7 @@ namespace graph{
             for(int d = 0; d < 3; ++d) {
                 NIFTY_CHECK_OP(affinities.shape(d+1), ==, longRangeAdjacency.shape(d), "Wrong shape");
             }
-            size_t nStats = 9;
+            std::size_t nStats = 9;
             nifty::marray::PyView<float> features({longRangeAdjacency.numberOfEdges(), nStats});
             {
                 py::gil_scoped_release allowThreads;

--- a/src/python/lib/graph/opt/lifted_multicut/lifted_graph_features.cxx
+++ b/src/python/lib/graph/opt/lifted_multicut/lifted_graph_features.cxx
@@ -31,8 +31,8 @@ namespace lifted_multicut{
                 marray::PyView<double,1> nodeSizes,
                 std::vector<double > sizeRegularizers
             ){
-                const size_t numberOfFeatures = sizeRegularizers.size() * 2;
-                const size_t numberOfLiftedEdges = objective.numberOfLiftedEdges();
+                const std::size_t numberOfFeatures = sizeRegularizers.size() * 2;
+                const std::size_t numberOfLiftedEdges = objective.numberOfLiftedEdges();
                 marray::PyView<double> out({numberOfFeatures, numberOfLiftedEdges});
 
                 {

--- a/src/python/lib/graph/opt/lifted_multicut/lifted_multicut_objective.cxx
+++ b/src/python/lib/graph/opt/lifted_multicut/lifted_multicut_objective.cxx
@@ -53,7 +53,7 @@ namespace lifted_multicut{
                 NIFTY_CHECK_OP(uvIds.shape(1),==,2,"wrong shape");
                 NIFTY_CHECK_OP(uvIds.shape(0),==,weights.shape(0),"wrong shape");
 
-                for(size_t i=0; i<uvIds.shape(0); ++i){
+                for(std::size_t i=0; i<uvIds.shape(0); ++i){
                     objective.setCost(uvIds(i,0), uvIds(i,1), weights(i),overwrite);
                 }
                 
@@ -147,7 +147,7 @@ namespace lifted_multicut{
                     self.insertLiftedEdgesBfs(maxDistance, dist);
                     nifty::marray::PyView<uint64_t> array({dist.size()});
 
-                    for(size_t i=0; i<dist.size(); ++i){
+                    for(std::size_t i=0; i<dist.size(); ++i){
                         array(i) = dist[i];
                     }
                     return array;

--- a/src/python/lib/graph/rag/accumulate_affinities.cxx
+++ b/src/python/lib/graph/rag/accumulate_affinities.cxx
@@ -52,7 +52,7 @@ namespace graph{
             marray::PyView<uint32_t> lnhOut({nLifted, uint64_t(2)});
             {
                 py::gil_scoped_release allowThreads;
-                for(size_t e = 0; e < nLifted; ++e) {
+                for(std::size_t e = 0; e < nLifted; ++e) {
                     lnhOut(e, 0) = lnh.u(e);
                     lnhOut(e, 1) = lnh.v(e);
                 }

--- a/src/python/lib/graph/rag/accumulate_filters_stacked.cxx
+++ b/src/python/lib/graph/rag/accumulate_filters_stacked.cxx
@@ -121,8 +121,8 @@ namespace graph{
             const RAG & rag,
             DATA & data,
             const std::vector<std::pair<uint64_t,uint64_t>> & skipEdges,
-            const std::vector<size_t> & skipRanges,
-            const std::vector<size_t> & skipStarts,
+            const std::vector<std::size_t> & skipRanges,
+            const std::vector<std::size_t> & skipStarts,
             const int zDirection,
             const int numberOfThreads
         ){

--- a/src/python/lib/graph/rag/accumulate_filters_stacked.cxx
+++ b/src/python/lib/graph/rag/accumulate_filters_stacked.cxx
@@ -120,7 +120,7 @@ namespace graph{
         [](
             const RAG & rag,
             DATA & data,
-            const std::vector<std::pair<size_t,size_t>> & skipEdges,
+            const std::vector<std::pair<uint64_t,uint64_t>> & skipEdges,
             const std::vector<size_t> & skipRanges,
             const std::vector<size_t> & skipStarts,
             const int zDirection,

--- a/src/python/lib/graph/rag/accumulate_stacked.cxx
+++ b/src/python/lib/graph/rag/accumulate_stacked.cxx
@@ -102,12 +102,12 @@ namespace graph{
         [](
             const RAG & rag,
             const std::vector<std::pair<uint64_t,uint64_t>> & skipEdges,
-            const std::vector<size_t> & skipRanges,
-            const std::vector<size_t> & skipStarts,
+            const std::vector<std::size_t> & skipRanges,
+            const std::vector<std::size_t> & skipStarts,
             const int numberOfThreads
         ){
-            size_t nSkipEdges = skipEdges.size();
-            std::vector<size_t> out(nSkipEdges);
+            std::size_t nSkipEdges = skipEdges.size();
+            std::vector<std::size_t> out(nSkipEdges);
             {
                 py::gil_scoped_release allowThreads;
                 getSkipEdgeLengths(rag,

--- a/src/python/lib/graph/rag/accumulate_stacked.cxx
+++ b/src/python/lib/graph/rag/accumulate_stacked.cxx
@@ -101,7 +101,7 @@ namespace graph{
         ragModule.def("getSkipEdgeLengths",
         [](
             const RAG & rag,
-            const std::vector<std::pair<size_t,size_t>> & skipEdges,
+            const std::vector<std::pair<uint64_t,uint64_t>> & skipEdges,
             const std::vector<size_t> & skipRanges,
             const std::vector<size_t> & skipStarts,
             const int numberOfThreads

--- a/src/python/lib/graph/rag/graph_accumulator.cxx
+++ b/src/python/lib/graph/rag/graph_accumulator.cxx
@@ -77,14 +77,14 @@ namespace graph{
         [](
             const RAG & rag,
             const uint64_t z,
-            std::map<size_t,std::vector<NODE_TYPE>> & defectNodes, // all defect nodes
+            std::map<std::size_t,std::vector<NODE_TYPE>> & defectNodes, // all defect nodes
             const bool lowerIsCompletelyDefected
         ){
-            std::vector<size_t> deleteEdges;
-            std::vector<size_t> ignoreEdges;
+            std::vector<std::size_t> deleteEdges;
+            std::vector<std::size_t> ignoreEdges;
 
             std::vector<std::pair<NODE_TYPE,NODE_TYPE>> skipEdges;
-            std::vector<size_t> skipRanges;
+            std::vector<std::size_t> skipRanges;
             {
                 py::gil_scoped_release allowThreads;
                 getSkipEdgesForSlice(

--- a/src/python/lib/graph/rag/grid_rag.cxx
+++ b/src/python/lib/graph/rag/grid_rag.cxx
@@ -33,7 +33,7 @@ namespace graph{
     }
 
 
-    template<size_t DIM, class LABELS>
+    template<std::size_t DIM, class LABELS>
     void exportExpilictGridRagT(
         py::module & ragModule,
         const std::string & clsName,
@@ -95,7 +95,7 @@ namespace graph{
     }
 
     #ifdef WITH_HDF5
-    template<size_t DIM, class LABELS>
+    template<std::size_t DIM, class LABELS>
     void exportHdf5GridRagT(
         py::module & ragModule,
         const std::string & clsName,

--- a/src/python/lib/graph/rag/grid_rag_coordinates.cxx
+++ b/src/python/lib/graph/rag/grid_rag_coordinates.cxx
@@ -19,7 +19,7 @@ namespace graph{
 
     using namespace py;
 
-    template<size_t DIM, class RAG_TYPE>
+    template<std::size_t DIM, class RAG_TYPE>
     void exportGridRagCoordinatesT(py::module & module, const std::string & name) {
 
         typedef RagCoordinates<DIM, RAG_TYPE> CoordinatesType;
@@ -32,11 +32,11 @@ namespace graph{
         py::class_<CoordinatesType>(module, className.c_str())
         .def("topologicalEdgeCoordinates", [](const CoordinatesType & self, const int64_t edgeId){
             const auto & coords = self.edgeCoordinates(edgeId);
-            size_t nCoordinates = coords.size() / DIM;
+            std::size_t nCoordinates = coords.size() / DIM;
             marray::PyView<int32_t,DIM> out({nCoordinates,DIM});
-            size_t jj = 0;
-            for(size_t ii = 0; ii < nCoordinates; ++ii) {
-                for(size_t d = 0; d < DIM; ++d) {
+            std::size_t jj = 0;
+            for(std::size_t ii = 0; ii < nCoordinates; ++ii) {
+                for(std::size_t d = 0; d < DIM; ++d) {
                     out(ii,d) = coords[jj];
                     ++jj;
                 }
@@ -45,11 +45,11 @@ namespace graph{
         })
         .def("edgeCoordinates", [](const CoordinatesType & self, const int64_t edgeId){
             const auto & coords = self.edgeCoordinates(edgeId);
-            size_t nCoordinates = 2 * coords.size() / DIM;
+            std::size_t nCoordinates = 2 * coords.size() / DIM;
             marray::PyView<int32_t,DIM> out({nCoordinates,DIM});
-            size_t jj = 0;
-            for(size_t ii = 0; ii < nCoordinates / 2; ++ii) {
-                for(size_t d = 0; d < DIM; ++d) {
+            std::size_t jj = 0;
+            for(std::size_t ii = 0; ii < nCoordinates / 2; ++ii) {
+                for(std::size_t d = 0; d < DIM; ++d) {
                     out(2*ii, d)   = std::floor(coords[jj] / 2);
                     out(2*ii+1, d) = std::ceil( coords[jj] / 2);
                     ++jj;

--- a/src/python/lib/graph/rag/grid_rag_stacked.cxx
+++ b/src/python/lib/graph/rag/grid_rag_stacked.cxx
@@ -51,7 +51,7 @@ namespace graph{
             .def_property_readonly("shape",[](const GridRagType & self){return self.shape();})
             .def("minMaxLabelPerSlice",[](const GridRagType & self){
                 const auto & shape = self.shape();
-                nifty::marray::PyView<uint64_t, 2> out({size_t(shape[0]),size_t(2)});
+                nifty::marray::PyView<uint64_t, 2> out({std::size_t(shape[0]),std::size_t(2)});
                 for(auto sliceIndex = 0; sliceIndex<shape[0]; ++sliceIndex){
                     auto mima = self.minMaxNode(sliceIndex);
                     out(sliceIndex, 0) = mima.first;
@@ -61,7 +61,7 @@ namespace graph{
             })
             .def("numberOfNodesPerSlice",[](const GridRagType & self){
                 const auto & shape = self.shape();
-                nifty::marray::PyView<uint64_t,  1> out({size_t(shape[0])});
+                nifty::marray::PyView<uint64_t,  1> out({std::size_t(shape[0])});
                 for(auto sliceIndex = 0; sliceIndex<shape[0]; ++sliceIndex){
                     out(sliceIndex) =  self.numberOfNodes(sliceIndex);
                 }
@@ -69,7 +69,7 @@ namespace graph{
             })
             .def("numberOfInSliceEdges",[](const GridRagType & self){
                 const auto & shape = self.shape();
-                nifty::marray::PyView<uint64_t,  1> out({size_t(shape[0])});
+                nifty::marray::PyView<uint64_t,  1> out({std::size_t(shape[0])});
                 for(auto sliceIndex = 0; sliceIndex<shape[0]; ++sliceIndex){
                     out(sliceIndex) =  self.numberOfInSliceEdges(sliceIndex);
                 }
@@ -77,7 +77,7 @@ namespace graph{
             })
             .def("numberOfInBetweenSliceEdges",[](const GridRagType & self){
                 const auto & shape = self.shape();
-                nifty::marray::PyView<uint64_t,  1> out({size_t(shape[0])});
+                nifty::marray::PyView<uint64_t,  1> out({std::size_t(shape[0])});
                 for(auto sliceIndex = 0; sliceIndex<shape[0]; ++sliceIndex){
                     out(sliceIndex) =  self.numberOfInBetweenSliceEdges(sliceIndex);
                 }
@@ -85,7 +85,7 @@ namespace graph{
             })
             .def("inSliceEdgeOffset",[](const GridRagType & self){
                 const auto & shape = self.shape();
-                nifty::marray::PyView<uint64_t,  1> out({size_t(shape[0])});
+                nifty::marray::PyView<uint64_t,  1> out({std::size_t(shape[0])});
                 for(auto sliceIndex = 0; sliceIndex<shape[0]; ++sliceIndex){
                     out(sliceIndex) =  self.inSliceEdgeOffset(sliceIndex);
                 }
@@ -93,7 +93,7 @@ namespace graph{
             })
             .def("betweenSliceEdgeOffset",[](const GridRagType & self){
                 const auto & shape = self.shape();
-                nifty::marray::PyView<uint64_t,  1> out({size_t(shape[0])});
+                nifty::marray::PyView<uint64_t,  1> out({std::size_t(shape[0])});
                 for(auto sliceIndex = 0; sliceIndex<shape[0]; ++sliceIndex){
                     out(sliceIndex) =  self.betweenSliceEdgeOffset(sliceIndex);
                 }
@@ -187,7 +187,7 @@ namespace graph{
             .def("labelsProxy",&GridRagType::labelsProxy,py::return_value_policy::reference)
             .def("minMaxLabelPerSlice",[](const GridRagType & self){
                 const auto & shape = self.shape();
-                nifty::marray::PyView<uint64_t, 2> out({size_t(shape[0]),size_t(2)});
+                nifty::marray::PyView<uint64_t, 2> out({std::size_t(shape[0]),std::size_t(2)});
                 for(auto sliceIndex = 0; sliceIndex<shape[0]; ++sliceIndex){
                     auto mima = self.minMaxNode(sliceIndex);
                     out(sliceIndex, 0) = mima.first;
@@ -197,7 +197,7 @@ namespace graph{
             })
             .def("numberOfNodesPerSlice",[](const GridRagType & self){
                 const auto & shape = self.shape();
-                nifty::marray::PyView<uint64_t,  1> out({size_t(shape[0])});
+                nifty::marray::PyView<uint64_t,  1> out({std::size_t(shape[0])});
                 for(auto sliceIndex = 0; sliceIndex<shape[0]; ++sliceIndex){
                     out(sliceIndex) =  self.numberOfNodes(sliceIndex);
                 }
@@ -205,7 +205,7 @@ namespace graph{
             })
             .def("numberOfInSliceEdges",[](const GridRagType & self){
                 const auto & shape = self.shape();
-                nifty::marray::PyView<uint64_t,  1> out({size_t(shape[0])});
+                nifty::marray::PyView<uint64_t,  1> out({std::size_t(shape[0])});
                 for(auto sliceIndex = 0; sliceIndex<shape[0]; ++sliceIndex){
                     out(sliceIndex) =  self.numberOfInSliceEdges(sliceIndex);
                 }
@@ -213,7 +213,7 @@ namespace graph{
             })
             .def("numberOfInBetweenSliceEdges",[](const GridRagType & self){
                 const auto & shape = self.shape();
-                nifty::marray::PyView<uint64_t,  1> out({size_t(shape[0])});
+                nifty::marray::PyView<uint64_t,  1> out({std::size_t(shape[0])});
                 for(auto sliceIndex = 0; sliceIndex<shape[0]; ++sliceIndex){
                     out(sliceIndex) =  self.numberOfInBetweenSliceEdges(sliceIndex);
                 }
@@ -221,7 +221,7 @@ namespace graph{
             })
             .def("inSliceEdgeOffset",[](const GridRagType & self){
                 const auto & shape = self.shape();
-                nifty::marray::PyView<uint64_t,  1> out({size_t(shape[0])});
+                nifty::marray::PyView<uint64_t,  1> out({std::size_t(shape[0])});
                 for(auto sliceIndex = 0; sliceIndex<shape[0]; ++sliceIndex){
                     out(sliceIndex) =  self.inSliceEdgeOffset(sliceIndex);
                 }
@@ -229,7 +229,7 @@ namespace graph{
             })
             .def("betweenSliceEdgeOffset",[](const GridRagType & self){
                 const auto & shape = self.shape();
-                nifty::marray::PyView<uint64_t,  1> out({size_t(shape[0])});
+                nifty::marray::PyView<uint64_t,  1> out({std::size_t(shape[0])});
                 for(auto sliceIndex = 0; sliceIndex<shape[0]; ++sliceIndex){
                     out(sliceIndex) =  self.betweenSliceEdgeOffset(sliceIndex);
                 }

--- a/src/python/lib/graph/undirected_grid_graph.cxx
+++ b/src/python/lib/graph/undirected_grid_graph.cxx
@@ -18,7 +18,7 @@ namespace nifty{
 namespace graph{
 
 
-    template<size_t DIM>
+    template<std::size_t DIM>
     void exportUndirectedGridGraphT(py::module & module) {
 
         typedef UndirectedGridGraph<DIM,true> GraphType;
@@ -143,9 +143,9 @@ namespace graph{
                     g.longRangeAffinitiesToLiftedEdges(affinities, edgeMap, ranges.begin(), axes.begin());
                     // extract edge values and lifted uv-ides from the edge map
                     nifty::marray::PyView<float, 1> values({edgeMap.size()});
-                    std::vector<size_t> uvShape = {edgeMap.size(), 2};
+                    std::vector<std::size_t> uvShape = {edgeMap.size(), 2};
                     nifty::marray::PyView<float, 2> liftedUvs(uvShape.begin(), uvShape.end());
-                    size_t i = 0;
+                    std::size_t i = 0;
                     for(const auto & mapVal : edgeMap) {
                         values[i] = mapVal.second;
                         liftedUvs[i,0] = mapVal.first.first;

--- a/src/python/lib/graph/undirected_list_graph.cxx
+++ b/src/python/lib/graph/undirected_list_graph.cxx
@@ -33,7 +33,7 @@ namespace graph{
                 [](Graph & g, nifty::marray::PyView<uint64_t> array) {
                     NIFTY_CHECK_OP(array.dimension(),==,2,"wrong dimensions");
                     NIFTY_CHECK_OP(array.shape(1),==,2,"wrong shape");
-                    for(size_t i=0; i<array.shape(0); ++i){
+                    for(std::size_t i=0; i<array.shape(0); ++i){
                         g.insertEdge(array(i,0),array(i,1));
                     }
                 }

--- a/src/python/lib/ground_truth/overlap.cxx
+++ b/src/python/lib/ground_truth/overlap.cxx
@@ -83,7 +83,7 @@ namespace ground_truth{
 
                 return out;
             })
-            .def("overlapArrays", [](const OverlapType & self, const size_t index, const bool sorted){
+            .def("overlapArrays", [](const OverlapType & self, const std::size_t index, const bool sorted){
 
                 typedef nifty::marray::PyView<uint64_t>  ArrayType;
                 const auto & overlaps = self.overlaps();
@@ -126,7 +126,7 @@ namespace ground_truth{
             }, py::arg("index"),py::arg("sorted") = false
             )
 
-            .def("overlapArraysNormalized", [](const OverlapType & self, const size_t index, const bool sorted){
+            .def("overlapArraysNormalized", [](const OverlapType & self, const std::size_t index, const bool sorted){
 
                 const auto & overlaps = self.overlaps();
                 const auto & olMap = overlaps[index];

--- a/src/python/lib/ground_truth/seg_to_edges.cxx
+++ b/src/python/lib/ground_truth/seg_to_edges.cxx
@@ -21,8 +21,8 @@ namespace ground_truth{
             marray::PyView<uint32_t, 2 >   seg
         ){
             marray::PyView<uint8_t> out({
-                size_t(seg.shape(0)),
-                size_t(seg.shape(1)),
+                std::size_t(seg.shape(0)),
+                std::size_t(seg.shape(1)),
             }); 
         
             segToEdges2D(seg, out);

--- a/src/python/lib/ground_truth/seg_to_lifted_edges.cxx
+++ b/src/python/lib/ground_truth/seg_to_lifted_edges.cxx
@@ -24,13 +24,13 @@ namespace ground_truth{
         ){
             NIFTY_CHECK_OP(edges.shape(1), == , 2, "edges must be |N| x 2")
             marray::PyView<uint8_t> out({
-                size_t(seg.shape(0)),
-                size_t(seg.shape(1)),
-                size_t(edges.shape(0))
+                std::size_t(seg.shape(0)),
+                std::size_t(seg.shape(1)),
+                std::size_t(edges.shape(0))
             }); 
             
             std::vector<std::array<int32_t, 2> > e(edges.shape(0));
-            for(size_t i=0; i<e.size(); ++i){
+            for(std::size_t i=0; i<e.size(); ++i){
                 e[i][0] = edges(i, 0);
                 e[i][1] = edges(i, 1);
             }
@@ -55,13 +55,13 @@ namespace ground_truth{
             NIFTY_CHECK_OP(edges.shape(1), == , 3, "edges must be |N| x 3");
 
             marray::PyView<uint8_t> out({
-                size_t(seg.shape(0)),
-                size_t(seg.shape(1)),
-                size_t(edges.shape(0))
+                std::size_t(seg.shape(0)),
+                std::size_t(seg.shape(1)),
+                std::size_t(edges.shape(0))
             }); 
             
             std::vector<std::array<int32_t, 3> > e(edges.shape(0));
-            for(size_t i=0; i<e.size(); ++i){
+            for(std::size_t i=0; i<e.size(); ++i){
                 e[i][0] = edges(i, 0);
                 e[i][1] = edges(i, 1);
                 e[i][2] = edges(i, 2);
@@ -88,13 +88,13 @@ namespace ground_truth{
             NIFTY_CHECK_OP(edges.shape(1), == , 4, "edges must be |N| x 4");
 
             marray::PyView<uint8_t> out({
-                size_t(seg.shape(0)),
-                size_t(seg.shape(1)),
-                size_t(edges.shape(0))
+                std::size_t(seg.shape(0)),
+                std::size_t(seg.shape(1)),
+                std::size_t(edges.shape(0))
             }); 
 
             std::vector<std::array<int32_t, 4> > e(edges.shape(0));
-            for(size_t i=0; i<e.size(); ++i){
+            for(std::size_t i=0; i<e.size(); ++i){
                 e[i][0] = edges(i, 0);
                 e[i][1] = edges(i, 1);
                 e[i][2] = edges(i, 2);
@@ -120,20 +120,20 @@ namespace ground_truth{
             NIFTY_CHECK_OP(edges.shape(1), == , 4, "edges must be |N| x 4");
 
             marray::PyView<uint8_t> out({
-                size_t(seg.shape(0)),
-                size_t(seg.shape(1)),
-                size_t(edges.shape(0))
+                std::size_t(seg.shape(0)),
+                std::size_t(seg.shape(1)),
+                std::size_t(edges.shape(0))
             }); 
 
             marray::PyView<float> w({
-                size_t(seg.shape(0)),
-                size_t(seg.shape(1)),
-                size_t(edges.shape(0))
+                std::size_t(seg.shape(0)),
+                std::size_t(seg.shape(1)),
+                std::size_t(edges.shape(0))
             }); 
             
             std::vector<std::array<int32_t, 4> > e(edges.shape(0));
             std::vector<float>                   p(edges.shape(0));
-            for(size_t i=0; i<e.size(); ++i){
+            for(std::size_t i=0; i<e.size(); ++i){
                 p[i] = edge_priors()
                 e[i][0] = edges(i, 0);
                 e[i][1] = edges(i, 1);
@@ -167,8 +167,8 @@ namespace ground_truth{
             
 
             marray::PyView<float> out({
-                size_t(seg.shape(0)),
-                size_t(seg.shape(1))
+                std::size_t(seg.shape(0)),
+                std::size_t(seg.shape(1))
             }); 
 
 
@@ -194,20 +194,20 @@ namespace ground_truth{
             NIFTY_CHECK_OP(edges.shape(1), == , 4, "edges must be |N| x 4");
 
             marray::PyView<uint8_t> out({
-                size_t(seg.shape(0)),
-                size_t(seg.shape(1)),
-                size_t(edges.shape(0))
+                std::size_t(seg.shape(0)),
+                std::size_t(seg.shape(1)),
+                std::size_t(edges.shape(0))
             }); 
 
             marray::PyView<float> w({
-                size_t(seg.shape(0)),
-                size_t(seg.shape(1)),
-                size_t(edges.shape(0))
+                std::size_t(seg.shape(0)),
+                std::size_t(seg.shape(1)),
+                std::size_t(edges.shape(0))
             }); 
             
             std::vector<std::array<int32_t, 4> > e(edges.shape(0));
             std::vector<float>                   p(edges.shape(0));
-            for(size_t i=0; i<e.size(); ++i){
+            for(std::size_t i=0; i<e.size(); ++i){
                 p[i] = edge_priors()
                 e[i][0] = edges(i, 0);
                 e[i][1] = edges(i, 1);

--- a/src/python/lib/hdf5/hdf5_array.cxx
+++ b/src/python/lib/hdf5/hdf5_array.cxx
@@ -27,8 +27,8 @@ namespace hdf5{
                 Hdf5ArrayType & instance,
                 const hid_t & groupHandle,
                 const std::string & datasetName,
-                std::vector<size_t> shape,
-                std::vector<size_t> chunkShape,
+                std::vector<std::size_t> shape,
+                std::vector<std::size_t> chunkShape,
                 const int compression
             ){
                 NIFTY_CHECK_OP(shape.size(), == ,chunkShape.size(), 
@@ -54,20 +54,20 @@ namespace hdf5{
             })
             .def("setOffsetFront",[](
                 Hdf5ArrayType & array,
-                std::vector<size_t> offsetFront
+                std::vector<std::size_t> offsetFront
             ){
                 return array.setOffsetFront(offsetFront.begin());
             })
             .def("setOffsetBack",[](
                 Hdf5ArrayType & array,
-                std::vector<size_t> offsetBack
+                std::vector<std::size_t> offsetBack
             ){
                 return array.setOffsetBack(offsetBack.begin());
             })
             .def("readSubarray",[](
                 const Hdf5ArrayType & array,
-                std::vector<size_t> roiBegin,
-                std::vector<size_t> roiEnd
+                std::vector<std::size_t> roiBegin,
+                std::vector<std::size_t> roiEnd
             ){
                 //std::cout<<"READ\n";
                 
@@ -82,8 +82,8 @@ namespace hdf5{
                 NIFTY_CHECK_OP(roiEnd.size(),==,dim,  "`roiEnd`has wrong size");
 
                 //std::cout<<"make shape\n";
-                std::vector<size_t> shape(dim);
-                for(size_t d=0; d<dim; ++d){
+                std::vector<std::size_t> shape(dim);
+                for(std::size_t d=0; d<dim; ++d){
                     shape[d] = roiEnd[d] - roiBegin[d];
                     //std::cout<<"s "<< shape[d]<<"\n";
                 }
@@ -112,7 +112,7 @@ namespace hdf5{
 
             .def("writeSubarray",[](
                 Hdf5ArrayType & array,
-                std::vector<size_t> roiBegin,
+                std::vector<std::size_t> roiBegin,
                 nifty::marray::PyView<T> in
             ){
                 const auto dim = array.dimension();

--- a/src/python/lib/malis/malis_gradient.cxx
+++ b/src/python/lib/malis/malis_gradient.cxx
@@ -24,8 +24,8 @@ namespace malis {
                 Coord shape;
                 for(int d = 0; d < DIM+1; ++d)
                     shape[d] = affinities.shape(d);
-                nifty::marray::PyView<size_t, DIM+1> positiveGradients(shape.begin(), shape.end());
-                nifty::marray::PyView<size_t, DIM+1> negativeGradients(shape.begin(), shape.end());
+                nifty::marray::PyView<std::size_t, DIM+1> positiveGradients(shape.begin(), shape.end());
+                nifty::marray::PyView<std::size_t, DIM+1> negativeGradients(shape.begin(), shape.end());
                 {
                     py::gil_scoped_release allowThreads;
                     compute_malis_gradient<DIM>(affinities, groundtruth, positiveGradients, negativeGradients);

--- a/src/python/lib/tools/blocking.cxx
+++ b/src/python/lib/tools/blocking.cxx
@@ -16,7 +16,7 @@ namespace nifty{
 namespace tools{
 
 
-    template<size_t DIM>
+    template<std::size_t DIM>
     void exportBlockingT(py::module & toolsModule){
         const auto dimStr = std::to_string(DIM) + std::string("d");
 
@@ -105,8 +105,8 @@ namespace tools{
 
             .def("getLocalOverlaps", [](
                 const BlockingType & self,
-                const size_t indexA,
-                const size_t indexB,
+                const std::size_t indexA,
+                const std::size_t indexB,
                 const VectorType blockHalo) {
 
                 VectorType blockABegin, blockBBegin, blockAEnd, blockBEnd;
@@ -120,7 +120,7 @@ namespace tools{
 
             .def("getBlockWithHalo", [](
                     const BlockingType & self,
-                    const size_t blockIndex,
+                    const std::size_t blockIndex,
                     const VectorType halo
                 ){
                     return self.getBlockWithHalo(blockIndex, halo);
@@ -129,7 +129,7 @@ namespace tools{
             )
             .def("getBlockWithHalo", [](
                     const BlockingType & self,
-                    const size_t blockIndex,
+                    const std::size_t blockIndex,
                     const VectorType haloBegin,
                     const VectorType haloEnd
                 ){

--- a/src/python/lib/tools/edge_mapping.cxx
+++ b/src/python/lib/tools/edge_mapping.cxx
@@ -19,7 +19,7 @@ namespace tools{
 
         typedef EdgeMapping<EdgeType, NodeType> MappingType;
         py::class_<MappingType>(toolsModule, "EdgeMapping")
-            .def(py::init<size_t>())
+            .def(py::init<std::size_t>())
 
             .def("initializeMapping",
                 [](MappingType & self, const marray::PyView<EdgeType> uvIds, const std::vector<NodeType> & oldToNewNodes) {
@@ -44,7 +44,7 @@ namespace tools{
             .def("getNewUvIds",
                 [](const MappingType & self) {
 
-                    size_t shape[] = {self.numberOfNewEdges(), 2};
+                    std::size_t shape[] = {self.numberOfNewEdges(), 2};
                     marray::PyView<EdgeType> newUvIds(shape, shape + 2);
 
                     {
@@ -52,7 +52,7 @@ namespace tools{
                         const auto & newUvIdsInternal = self.getNewUvIds();
 
                         // this could also be parallelized
-                        for(size_t i = 0; i < self.numberOfNewEdges(); ++i) {
+                        for(std::size_t i = 0; i < self.numberOfNewEdges(); ++i) {
                             newUvIds(i, 0) = newUvIdsInternal[i].first;
                             newUvIds(i, 1) = newUvIdsInternal[i].second;
                         }

--- a/src/python/lib/tools/sleep.cxx
+++ b/src/python/lib/tools/sleep.cxx
@@ -10,7 +10,7 @@ namespace nifty{
 namespace tools{
 
 void exportSleep(py::module & toolsModule) {
-    toolsModule.def("sleepMilliseconds",[](size_t nMilliseconds) {
+    toolsModule.def("sleepMilliseconds",[](std::size_t nMilliseconds) {
         py::gil_scoped_release allowThreads;
         std::this_thread::sleep_for(std::chrono::milliseconds(nMilliseconds));
     },

--- a/src/python/lib/tools/take.cxx
+++ b/src/python/lib/tools/take.cxx
@@ -43,7 +43,7 @@ namespace tools{
 
 
                 timer.startAndPrint("work");
-                for(size_t i=0; i<toRelabel.shape(0); ++i){
+                for(std::size_t i=0; i<toRelabel.shape(0); ++i){
                     out(i) = relabeling(toRelabel(i));
                 }
 
@@ -53,7 +53,7 @@ namespace tools{
                 //auto po = &out[0];
                 //auto pr = &relabeling[0];
                 //auto pt = & toRelabel[0];
-                //for(size_t i=0; i<toRelabel.shape(0); ++i){
+                //for(std::size_t i=0; i<toRelabel.shape(0); ++i){
                 //    po[i] = pr[pt[i]];
                 //}
 

--- a/src/test/test_features/test_fastfilters_wrapper.cxx
+++ b/src/test/test_features/test_fastfilters_wrapper.cxx
@@ -157,7 +157,7 @@ auto get3DTestData() {
 BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest2D)
 {
 
-    std::vector<size_t> shapeIn({5,5});
+    std::vector<std::size_t> shapeIn({5,5});
     nifty::marray::Marray<float> in(shapeIn.begin(), shapeIn.end());
     std::fill(in.begin(), in.end(), 0.);
     in(2,2) = 1.;
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest2D)
 
     ApplyFilters<2> functor(sigmas, filtersToSigmas);
 
-    std::vector<size_t> shapeOut({functor.numberOfChannels(),shapeIn[0],shapeIn[1]});
+    std::vector<std::size_t> shapeOut({functor.numberOfChannels(),shapeIn[0],shapeIn[1]});
     nifty::marray::Marray<float> out(shapeOut.begin(), shapeOut.end());
 
     functor(in, out);
@@ -187,8 +187,8 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest2D)
     auto testData = get2DTestData();
 
     // test filter responses for correctnes for first sigma val
-    for(size_t y = 0; y < in.shape(0); y++) { 
-        for(size_t x = 0; x < in.shape(1); x++) { 
+    for(std::size_t y = 0; y < in.shape(0); y++) { 
+        for(std::size_t x = 0; x < in.shape(1); x++) { 
             NIFTY_CHECK_EQ_TOL(out(0,y,x),std::get<0>(testData)[y][x],1e-6)
             NIFTY_CHECK_EQ_TOL(out(1,y,x),std::get<1>(testData)[y][x],1e-6)
             NIFTY_CHECK_EQ_TOL(out(2,y,x),std::get<2>(testData)[y][x],1e-6)
@@ -203,15 +203,15 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest2DPresmooth)
 {
 
     // create random test data
-    std::vector<size_t> shapeIn({100,100});
+    std::vector<std::size_t> shapeIn({100,100});
     nifty::marray::Marray<float> in(shapeIn.begin(), shapeIn.end());
 
     std::default_random_engine generator;
     std::uniform_real_distribution<float> distr(0.,1.);
     auto draw = std::bind( distr, generator );
 
-    for(size_t ii = 0; ii < in.shape(0); ++ii) {
-        for(size_t jj = 0; jj < in.shape(1); ++jj)
+    for(std::size_t ii = 0; ii < in.shape(0); ++ii) {
+        for(std::size_t jj = 0; jj < in.shape(1); ++jj)
             in(ii,jj) = draw();
     }
 
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest2DPresmooth)
 
     ApplyFilters<2> functor(sigmas, filtersToSigmas);
 
-    std::vector<size_t> shapeOut({functor.numberOfChannels(),shapeIn[0],shapeIn[1]});
+    std::vector<std::size_t> shapeOut({functor.numberOfChannels(),shapeIn[0],shapeIn[1]});
     nifty::marray::Marray<float> outExpected(shapeOut.begin(), shapeOut.end());
     nifty::marray::Marray<float> outActual(shapeOut.begin(), shapeOut.end());
 
@@ -241,9 +241,9 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest2DPresmooth)
 
     // test filter responses for correctnes for first sigma val
     double tolerance = 1e-1; // we pass only if we allow for first tolerance after the first comma
-    for(size_t c = 0; c < outActual.shape(0); ++c) { 
-        for(size_t x = 0; x < outActual.shape(1); ++x) { 
-            for(size_t y = 0; y < outActual.shape(2); ++y) { 
+    for(std::size_t c = 0; c < outActual.shape(0); ++c) { 
+        for(std::size_t x = 0; x < outActual.shape(1); ++x) { 
+            for(std::size_t y = 0; y < outActual.shape(2); ++y) { 
                 NIFTY_CHECK_EQ_TOL(outActual(c,x,y),outExpected(c,x,y),tolerance);
             }
         }
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest2DPresmooth)
 BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest2DParallel)
 {
 
-    std::vector<size_t> shapeIn({5,5});
+    std::vector<std::size_t> shapeIn({5,5});
     nifty::marray::Marray<float> in(shapeIn.begin(), shapeIn.end());
     std::fill(in.begin(), in.end(), 0.);
     in(2,2) = 1.;
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest2DParallel)
 
     ApplyFilters<2> functor(sigmas, filtersToSigmas);
 
-    std::vector<size_t> shapeOut({functor.numberOfChannels(),shapeIn[0],shapeIn[1]});
+    std::vector<std::size_t> shapeOut({functor.numberOfChannels(),shapeIn[0],shapeIn[1]});
     nifty::marray::Marray<float> out(shapeOut.begin(), shapeOut.end());
 
     nifty::parallel::ParallelOptions pOpts(-1);
@@ -287,8 +287,8 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest2DParallel)
     auto testData = get2DTestData();
 
     // test filter responses for correctnes for first sigma val
-    for(size_t y = 0; y < in.shape(0); y++) {
-        for(size_t x = 0; x < in.shape(1); x++) {
+    for(std::size_t y = 0; y < in.shape(0); y++) {
+        for(std::size_t x = 0; x < in.shape(1); x++) {
             NIFTY_CHECK_EQ_TOL(out(0,y,x),std::get<0>(testData)[y][x],1e-6)
             NIFTY_CHECK_EQ_TOL(out(1,y,x),std::get<1>(testData)[y][x],1e-6)
             NIFTY_CHECK_EQ_TOL(out(2,y,x),std::get<2>(testData)[y][x],1e-6)
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest2DParallel)
 BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest3D)
 {
 
-    std::vector<size_t> shapeIn({5,5,5});
+    std::vector<std::size_t> shapeIn({5,5,5});
     nifty::marray::Marray<float> in(shapeIn.begin(), shapeIn.end());
     std::fill(in.begin(), in.end(), 0.);
     in(2,2,2) = 1.;
@@ -319,7 +319,7 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest3D)
 
     ApplyFilters<3> functor(sigmas, filtersToSigmas);
 
-    std::vector<size_t> shapeOut({functor.numberOfChannels(),shapeIn[0],shapeIn[1],shapeIn[2]});
+    std::vector<std::size_t> shapeOut({functor.numberOfChannels(),shapeIn[0],shapeIn[1],shapeIn[2]});
     nifty::marray::Marray<float> out(shapeOut.begin(), shapeOut.end());
 
     functor(in, out);
@@ -333,9 +333,9 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest3D)
     auto testData = get3DTestData();
 
     // test filter responses for correctnes for first sigma val
-    for(size_t z = 0; z < in.shape(0); z++) {
-        for(size_t y = 0; y < in.shape(1); y++) { 
-            for(size_t x = 0; x < in.shape(2); x++) { 
+    for(std::size_t z = 0; z < in.shape(0); z++) {
+        for(std::size_t y = 0; y < in.shape(1); y++) { 
+            for(std::size_t x = 0; x < in.shape(2); x++) { 
                 NIFTY_CHECK_EQ_TOL(out(0,z,y,x),std::get<0>(testData)[z][y][x],1e-6)
                 NIFTY_CHECK_EQ_TOL(out(1,z,y,x),std::get<1>(testData)[z][y][x],1e-6)
                 NIFTY_CHECK_EQ_TOL(out(2,z,y,x),std::get<2>(testData)[z][y][x],1e-5)
@@ -350,16 +350,16 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest3DPresmooth)
 {
 
     // create random test data
-    std::vector<size_t> shapeIn({100,100,100});
+    std::vector<std::size_t> shapeIn({100,100,100});
     nifty::marray::Marray<float> in(shapeIn.begin(), shapeIn.end());
 
     std::default_random_engine generator;
     std::uniform_real_distribution<float> distr(0.,1.);
     auto draw = std::bind( distr, generator );
 
-    for(size_t ii = 0; ii < in.shape(0); ++ii) {
-        for(size_t jj = 0; jj < in.shape(1); ++jj){
-            for(size_t kk = 0; kk < in.shape(2); ++kk)
+    for(std::size_t ii = 0; ii < in.shape(0); ++ii) {
+        for(std::size_t jj = 0; jj < in.shape(1); ++jj){
+            for(std::size_t kk = 0; kk < in.shape(2); ++kk)
                 in(ii,jj,kk) = draw();
         }
     }
@@ -375,7 +375,7 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest3DPresmooth)
 
     ApplyFilters<3> functor(sigmas, filtersToSigmas);
 
-    std::vector<size_t> shapeOut({functor.numberOfChannels(),shapeIn[0],shapeIn[1],shapeIn[2]});
+    std::vector<std::size_t> shapeOut({functor.numberOfChannels(),shapeIn[0],shapeIn[1],shapeIn[2]});
     nifty::marray::Marray<float> outExpected(shapeOut.begin(), shapeOut.end());
     nifty::marray::Marray<float> outActual(shapeOut.begin(), shapeOut.end());
 
@@ -390,10 +390,10 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest3DPresmooth)
     // test filter responses for correctnes for first sigma val
     double tolerance = 1e-2; // we pass only if we allow for first tolerance after the first comma
     // apparently this is more robust in 3d than in 2d
-    for(size_t c = 0; c < outActual.shape(0); ++c) { 
-        for(size_t x = 0; x < outActual.shape(1); ++x) { 
-            for(size_t y = 0; y < outActual.shape(2); ++y) { 
-                for(size_t z = 0; z < outActual.shape(3); ++z) { 
+    for(std::size_t c = 0; c < outActual.shape(0); ++c) { 
+        for(std::size_t x = 0; x < outActual.shape(1); ++x) { 
+            for(std::size_t y = 0; y < outActual.shape(2); ++y) { 
+                for(std::size_t z = 0; z < outActual.shape(3); ++z) { 
                     NIFTY_CHECK_EQ_TOL(outActual(c,x,y,z),outExpected(c,x,y,z),tolerance);
                 }
             }
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest3DPresmooth)
 BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest3DParallel)
 {
 
-    std::vector<size_t> shapeIn({5,5,5});
+    std::vector<std::size_t> shapeIn({5,5,5});
     nifty::marray::Marray<float> in(shapeIn.begin(), shapeIn.end());
     std::fill(in.begin(), in.end(), 0.);
     in(2,2,2) = 1.;
@@ -422,7 +422,7 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest3DParallel)
 
     ApplyFilters<3> functor(sigmas, filtersToSigmas);
 
-    std::vector<size_t> shapeOut({functor.numberOfChannels(),shapeIn[0],shapeIn[1],shapeIn[2]});
+    std::vector<std::size_t> shapeOut({functor.numberOfChannels(),shapeIn[0],shapeIn[1],shapeIn[2]});
     nifty::marray::Marray<float> out(shapeOut.begin(), shapeOut.end());
 
     nifty::parallel::ParallelOptions pOpts(-1);
@@ -439,9 +439,9 @@ BOOST_AUTO_TEST_CASE(FastfiltersWrapperTest3DParallel)
     auto testData = get3DTestData();
 
     // test filter responses for correctnes for first sigma val
-    for(size_t z = 0; z < in.shape(0); z++) {
-        for(size_t y = 0; y < in.shape(1); y++) {
-            for(size_t x = 0; x < in.shape(2); x++) {
+    for(std::size_t z = 0; z < in.shape(0); z++) {
+        for(std::size_t y = 0; y < in.shape(1); y++) {
+            for(std::size_t x = 0; x < in.shape(2); x++) {
                 NIFTY_CHECK_EQ_TOL(out(0,z,y,x),std::get<0>(testData)[z][y][x],1e-6)
                 NIFTY_CHECK_EQ_TOL(out(1,z,y,x),std::get<1>(testData)[z][y][x],1e-6)
                 NIFTY_CHECK_EQ_TOL(out(2,z,y,x),std::get<2>(testData)[z][y][x],1e-5)

--- a/src/test/test_graph/test_edge_weighted_watersheds.cxx
+++ b/src/test/test_graph/test_edge_weighted_watersheds.cxx
@@ -21,7 +21,7 @@ void randomizedEdgeWeightedWatersheds()
 
 
     // create a grid graph
-    const size_t s = 30;
+    const std::size_t s = 30;
     Graph g(s*s);
     for(auto y=0; y<s; ++y)
     for(auto x=0; x<s; ++x){

--- a/src/test/test_graph/test_multicut.cxx
+++ b/src/test/test_graph/test_multicut.cxx
@@ -35,7 +35,7 @@ void randomizedMulticutTest()
 
 
     // create a grid graph
-    const size_t s = 15;
+    const std::size_t s = 15;
     Graph g(s*s);
     for(auto y=0; y<s; ++y)
     for(auto x=0; x<s; ++x){
@@ -131,8 +131,8 @@ void simpleMulticutTest()
 
 
     // create a grid graph
-    const size_t sx = 8;
-    const size_t sy = 13;
+    const std::size_t sx = 8;
+    const std::size_t sy = 13;
     auto node = [&](uint64_t x, uint64_t y){
         return x + y*sx;
     };
@@ -167,7 +167,7 @@ void simpleMulticutTest()
     }
 
     typename Graph::EdgeMap<uint16_t> shouldSolution(g,0);
-    for(size_t y=0; y<sy; ++y){
+    for(std::size_t y=0; y<sy; ++y){
         auto e = g.findEdge( node(3, y), node(3+1, y)  );
         shouldSolution[e] = 1;
     }

--- a/src/test/test_graph/test_rag/simple_rag_test.cxx
+++ b/src/test/test_graph/test_rag/simple_rag_test.cxx
@@ -10,7 +10,7 @@
 #include "nifty/graph/rag/grid_rag_stacked_2d_hdf5.hxx"
 
 void getStackedSegmentation(nifty::marray::Marray<uint32_t> & seg,
-        const std::vector<size_t> & shape) {
+        const std::vector<std::size_t> & shape) {
     // random generator
     std::default_random_engine gen;
     std::uniform_int_distribution<int> distr(0,9);
@@ -35,19 +35,19 @@ BOOST_AUTO_TEST_CASE(StackedRagHdf5Test)
 {
     typedef nifty::graph::Hdf5Labels<3, uint32_t> LabelsProxy;
 
-    std::vector<size_t> shape({20,100,100});
+    std::vector<std::size_t> shape({20,100,100});
     nifty::marray::Marray<uint32_t> seg(shape.begin(), shape.end());
     getStackedSegmentation(seg, shape);
     uint32_t maxLabel = *(std::max_element(seg.begin(), seg.end()));
     std::cout << "MaxLabel: " << maxLabel << std::endl;
     auto segFile = nifty::hdf5::createFile("./seg_tmp.h5");
-    std::vector<size_t> chunks({10,50,50});
+    std::vector<std::size_t> chunks({10,50,50});
     nifty::hdf5::Hdf5Array<uint32_t> labels(segFile,
             "data",
             shape.begin(),
             shape.end(),
             chunks.begin());
-    std::vector<size_t> start({0,0,0});
+    std::vector<std::size_t> start({0,0,0});
     labels.writeSubarray(start.begin(), seg);
     LabelsProxy labelsProxy(labels, maxLabel);
     nifty::graph::GridRagStacked2D<LabelsProxy> rag(labelsProxy);

--- a/src/test/test_marray.cxx
+++ b/src/test/test_marray.cxx
@@ -8,7 +8,7 @@
 void stridesTest()
 {
     {
-        std::vector<size_t> shape({10,20});
+        std::vector<std::size_t> shape({10,20});
         nifty::marray::Marray<int> a(shape.begin(), shape.end(),0, nifty::marray::FirstMajorOrder);
         NIFTY_TEST_OP(a.strides(0),==,20);
         NIFTY_TEST_OP(a.strides(1),==,1);
@@ -26,7 +26,7 @@ void stridesTest()
         
     }
     {
-        std::vector<size_t> shape({10,20});
+        std::vector<std::size_t> shape({10,20});
         nifty::marray::Marray<int> a(shape.begin(), shape.end(),0, nifty::marray::LastMajorOrder);
         
         NIFTY_TEST(a.coordinateOrder() == nifty::marray::LastMajorOrder);


### PR DESCRIPTION
To ensure portability, I changed the following:
* use `int64_t` instead of `L` or `LL` as only the explicit type works with MSVC, gcc and clang correctly
* prefix size_t with `std` because on windows it is ambiguous (there's a `size_t` outside of `std`)
* change the variables `WITH_GUROBI` and `WITH_CPLEX` to have values `0` or `1` as that works more consistently across all platforms

Additionally I added the windows conda build script, but for gurobi it currently uses a hard coded path.