### PR TITLE
just simple rename from `coordianteToNode` -> `coordianteToNode`.

### DIFF
--- a/include/nifty/graph/undirected_grid_graph.hxx
+++ b/include/nifty/graph/undirected_grid_graph.hxx
@@ -375,8 +375,8 @@ public:
                 }
             }
 
-            const std::size_t u = coordianteToNode(cU);
-            const std::size_t v = coordianteToNode(cV);
+            const std::size_t u = coordinateToNode(cU);
+            const std::size_t v = coordinateToNode(cV);
 
             const std::size_t e = findEdge(u, v);
             if(e == -1) {
@@ -441,8 +441,8 @@ public:
                 }
             }
 
-            const std::size_t u = coordianteToNode(cU);
-            const std::size_t v = coordianteToNode(cV);
+            const std::size_t u = coordinateToNode(cU);
+            const std::size_t v = coordinateToNode(cV);
 
             const std::size_t e = findEdge(u, v);
             if(e == -1) {
@@ -522,7 +522,7 @@ public:
     }
 
     template<class NODE_COORDINATE>
-    uint64_t coordianteToNode(const NODE_COORDINATE & coordinate)const{
+    uint64_t coordinateToNode(const NODE_COORDINATE & coordinate)const{
         AndresVertexCoordinate aCoordinate;
         for(auto d=0; d<DIM; ++d){
             aCoordinate[DIM-1-d] = coordinate[d];

--- a/include/nifty/graph/undirected_long_range_grid_graph.hxx
+++ b/include/nifty/graph/undirected_long_range_grid_graph.hxx
@@ -130,7 +130,7 @@ namespace graph{
             for(const auto & offset : offsets_){
                     const auto coordQ = offset + coordP;
                     if(coordQ.allInsideShape(shape_)){
-                        const auto v = this->coordianteToNode(coordQ);
+                        const auto v = this->coordinateToNode(coordQ);
                         const auto e = this->findEdge(u,v);
                         ret[e] = offsetIndex;
                     }
@@ -166,7 +166,7 @@ namespace graph{
                         if(coordQ.allInsideShape(shape_)){
 
                             const auto valQ = xt::view(nodeFeatures, coordQ[0],coordQ[1], xt::all());
-                            const auto v = this->coordianteToNode(coordQ);
+                            const auto v = this->coordinateToNode(coordQ);
                             const auto e = this->findEdge(u,v);
                             NIFTY_CHECK_OP(e,>=,0,"");
                             ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
@@ -183,7 +183,7 @@ namespace graph{
                         const auto coordQ = offset + coordP;
                         if(coordQ.allInsideShape(shape_)){
                             const auto valQ = xt::view(nodeFeatures, coordQ[0], coordQ[1], coordQ[2], xt::all());
-                            const auto v = this->coordianteToNode(coordQ);
+                            const auto v = this->coordinateToNode(coordQ);
                             const auto e = this->findEdge(u,v);
                             NIFTY_CHECK_OP(e,>=,0,"");
                             ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
@@ -221,7 +221,7 @@ namespace graph{
 
                             const auto valP = xt::view(nodeFeatures, coordP[0],coordP[1],offsetIndex, xt::all());
                             const auto valQ = xt::view(nodeFeatures, coordQ[0],coordQ[1],offsetIndex, xt::all());
-                            const auto v = this->coordianteToNode(coordQ);
+                            const auto v = this->coordinateToNode(coordQ);
                             const auto e = this->findEdge(u,v);
                             NIFTY_CHECK_OP(e,>=,0,"");
                             ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
@@ -242,7 +242,7 @@ namespace graph{
                         if(coordQ.allInsideShape(shape_)){
                             const auto valP = xt::view(nodeFeatures, coordP[0], coordP[1], coordP[2],offsetIndex, xt::all());
                             const auto valQ = xt::view(nodeFeatures, coordQ[0], coordQ[1], coordQ[2],offsetIndex, xt::all());
-                            const auto v = this->coordianteToNode(coordQ);
+                            const auto v = this->coordinateToNode(coordQ);
                             const auto e = this->findEdge(u,v);
                             NIFTY_CHECK_OP(e,>=,0,"");
                             ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
@@ -282,7 +282,7 @@ namespace graph{
                     const auto coordQ = offset + coordP;
                     if(coordQ.allInsideShape(shape_)){
 
-                        const auto v = this->coordianteToNode(coordQ);
+                        const auto v = this->coordinateToNode(coordQ);
                         const auto e = this->findEdge(u,v);
 
                         if(DIM == 2){
@@ -312,7 +312,7 @@ namespace graph{
         // }
 
         template<class NODE_COORDINATE>
-        uint64_t coordianteToNode(
+        uint64_t coordinateToNode(
             const NODE_COORDINATE & coordinate
         )const{
             uint64_t n = 0;

--- a/src/python/examples/graph/plot_undirected_grid_graph.py
+++ b/src/python/examples/graph/plot_undirected_grid_graph.py
@@ -53,7 +53,7 @@ for node in graph.nodes():
 # get the node of a coordinate
 for x0 in range(shape[0]):
     for x1 in range(shape[1]):
-        print("coordiante",[x0,x1],"node",graph.coordianteToNode([x0,x1]))
+        print("coordiante",[x0,x1],"node",graph.coordinateToNode([x0,x1]))
 
 
 ##############################################

--- a/src/python/lib/graph/undirected_grid_graph.cxx
+++ b/src/python/lib/graph/undirected_grid_graph.cxx
@@ -43,7 +43,7 @@ namespace graph{
                 const GraphType & g,
                 const typename GraphType::CoordinateType & coord
             ){
-                return g.coordianteToNode(coord);
+                return g.coordinateToNode(coord);
             })
 
             .def("euclideanEdgeMap",


### PR DESCRIPTION
ran across this since I was building with @DerThorsten's nifty repo and not with your fork, where you already have fixed the Python tests. In any case here I renamed all _typos_(?) of this `coordianteToNode` function to be consistent.

(change partly introduced in f46c8f1a813bda4c84000efdef5f354be4e7f677)