### PR TITLE
Add support for edge-mask longRangeGridGraph

### DIFF
--- a/include/nifty/graph/undirected_long_range_grid_graph.hxx
+++ b/include/nifty/graph/undirected_long_range_grid_graph.hxx
@@ -8,6 +8,8 @@
 #include "nifty/array/arithmetic_array.hxx"
 #include "nifty/tools/for_each_coordinate.hxx"
 
+#include <cstdlib>
+
 namespace nifty{
 namespace graph{
 
@@ -19,60 +21,49 @@ namespace graph{
     namespace detail_graph{
 
         template<std::size_t DIM>
-        class UndirectedLongRangeGridGraphAssign;
-
-        template<>
-        class UndirectedLongRangeGridGraphAssign<2>{
+        class UndirectedLongRangeGridGraphAssign{
         public:
-            template<class G>
+            template<class G, class D>
             static void assign(
-               G & graph
+                G & graph,
+                const xt::xexpression<D> & edgeMaskExp,
+                const bool hasMaskedEdges
+
             ){
+                const auto & edgeMask = edgeMaskExp.derived_cast();
                 const auto & shape = graph.shape();
                 const auto & offsets = graph.offsets();
-                uint64_t u=0;
-                for(int p0=0; p0< graph.shape()[0]; ++p0)
-                for(int p1=0; p1< graph.shape()[1]; ++p1){
-                    for(int io=0; io<offsets.size(); ++io){
-                        const int q0 = p0 + offsets[io][0];
-                        const int q1 = p1 + offsets[io][1];
-                        if(q0>=0 && q0<shape[0] && q1>=0 && q1<shape[1]){
-                            const auto v = q0*shape[1] + q1;
-                            const auto e = graph.insertEdge(u, v);
+
+                nifty::tools::forEachCoordinate(
+                    shape,
+                    [&](const auto & coordP){
+                        const auto u = graph.coordinateToNode(coordP);
+                        for(int io=0; io<offsets.size(); ++io){
+                            const auto offset = offsets[io];
+                            const auto coordQ = offset + coordP;
+
+                            // Check if both coordinates are in the volume:
+                            if(coordQ.allInsideShape(shape)){
+                                const auto v = graph.coordinateToNode(coordQ);
+                                bool isValidEdge = true;
+
+                                if (hasMaskedEdges)
+                                {
+                                    // Check if the edge should be added according to the mask:
+                                    array::StaticArray<int64_t, DIM + 1> maskIndex;
+                                    std::copy(std::begin(coordP), std::end(coordP), std::begin(maskIndex));
+                                    maskIndex[DIM] = io;
+                                    isValidEdge = edgeMask[maskIndex];
+                                }
+
+                                if (isValidEdge) {
+                                    // Insert new edge in graph:
+                                    graph.insertEdge(u, v);
+                                }
+                            }
                         }
                     }
-                    ++u;
-                }
-            }
-
-
-
-        };
-
-        template<>
-        class UndirectedLongRangeGridGraphAssign<3>{
-        public:
-            template<class G>
-            static void assign(
-                G & graph
-            ){
-                const auto & shape = graph.shape();
-                const auto & offsets = graph.offsets();
-                uint64_t u=0;
-                for(int p0=0; p0<shape[0]; ++p0)
-                for(int p1=0; p1<shape[1]; ++p1)
-                for(int p2=0; p2<shape[2]; ++p2){
-                    for(int io=0; io<offsets.size(); ++io){
-                        const int q0 = p0 + offsets[io][0];
-                        const int q1 = p1 + offsets[io][1];
-                        const int q2 = p2 + offsets[io][2];
-                        if(q0>=0 && q0<shape[0] && q1>=0 && q1<shape[1] && q2>=0 && q2<shape[2]){
-                            const auto v = q0*shape[1]*shape[2] + q1*shape[2] + q2;
-                            const auto e = graph.insertEdge(u, v);
-                        }
-                    }
-                    ++u;
-                }
+                );
             }
         };
     }
@@ -93,14 +84,17 @@ namespace graph{
 
         typedef std::vector<OffsetType>     OffsetVector;
 
-            
+        template<class D>
         UndirectedLongRangeGridGraph(
             const ShapeType &    shape,
-            const OffsetVector & offsets
+            const OffsetVector & offsets,
+            const xt::xexpression<D> & edgeMaskExp,
+            const bool hasMaskedEdges
         )
         :   UndirectedGraph<>(),
             shape_(shape),
-            offsets_(offsets)
+            offsets_(offsets),
+            hasMaskedEdges_(hasMaskedEdges)
         {
             NIFTY_CHECK(DIM==2 || DIM==3,"wrong dimension");
 
@@ -114,7 +108,7 @@ namespace graph{
             for(int d=int(DIM)-2; d>=0; --d){
                 strides_[d] = shape_[d+1] * strides_[d+1];
             }
-            HelperType::assign(*this);
+            HelperType::assign(*this, edgeMaskExp, hasMaskedEdges);
         }
 
 
@@ -132,7 +126,12 @@ namespace graph{
                     if(coordQ.allInsideShape(shape_)){
                         const auto v = this->coordinateToNode(coordQ);
                         const auto e = this->findEdge(u,v);
-                        ret[e] = offsetIndex;
+                        if (not this->hasMaskedEdges_) {
+                            NIFTY_CHECK_OP(e,>=,0,"");
+                            ret[e] = offsetIndex;
+                        } else if (e>=0) {
+                            ret[e] = offsetIndex;
+                        }
                     }
                     ++offsetIndex;
                 }
@@ -168,8 +167,13 @@ namespace graph{
                             const auto valQ = xt::view(nodeFeatures, coordQ[0],coordQ[1], xt::all());
                             const auto v = this->coordinateToNode(coordQ);
                             const auto e = this->findEdge(u,v);
-                            NIFTY_CHECK_OP(e,>=,0,"");
-                            ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
+
+                            if (not this->hasMaskedEdges_) {
+                                NIFTY_CHECK_OP(e,>=,0,"");
+                                ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
+                            } else if (e>=0) {
+                                ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
+                            }
                         }
                     }
                     ++u;
@@ -185,8 +189,12 @@ namespace graph{
                             const auto valQ = xt::view(nodeFeatures, coordQ[0], coordQ[1], coordQ[2], xt::all());
                             const auto v = this->coordinateToNode(coordQ);
                             const auto e = this->findEdge(u,v);
-                            NIFTY_CHECK_OP(e,>=,0,"");
-                            ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
+                            if (not this->hasMaskedEdges_) {
+                                NIFTY_CHECK_OP(e,>=,0,"");
+                                ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
+                            } else if (e>=0) {
+                                ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
+                            }
                         }
                     }
                     ++u;
@@ -223,8 +231,12 @@ namespace graph{
                             const auto valQ = xt::view(nodeFeatures, coordQ[0],coordQ[1],offsetIndex, xt::all());
                             const auto v = this->coordinateToNode(coordQ);
                             const auto e = this->findEdge(u,v);
-                            NIFTY_CHECK_OP(e,>=,0,"");
-                            ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
+                            if (not this->hasMaskedEdges_) {
+                                NIFTY_CHECK_OP(e,>=,0,"");
+                                ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
+                            } else if (e>=0) {
+                                ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
+                            }
                         }
                         ++offsetIndex;
                     }
@@ -244,8 +256,12 @@ namespace graph{
                             const auto valQ = xt::view(nodeFeatures, coordQ[0], coordQ[1], coordQ[2],offsetIndex, xt::all());
                             const auto v = this->coordinateToNode(coordQ);
                             const auto e = this->findEdge(u,v);
-                            NIFTY_CHECK_OP(e,>=,0,"");
-                            ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
+                            if (not this->hasMaskedEdges_) {
+                                NIFTY_CHECK_OP(e,>=,0,"");
+                                ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
+                            } else if (e>=0) {
+                                ret[e] = xt::sum(xt::pow(valP-valQ, 2))();
+                            }
                         }
                         offsetIndex+=1;
                     }
@@ -255,6 +271,32 @@ namespace graph{
             return ret;
         }
 
+        template<class D>
+        auto nodeValues(
+                const xt::xexpression<D> & valuesExpression
+        )const {
+
+            typedef typename D::value_type value_type;
+            const auto &values = valuesExpression.derived_cast();
+
+            for (auto d = 0; d < DIM; ++d) {
+                NIFTY_CHECK_OP(shape_[d], == , values.shape()[d], "input has wrong shape");
+            }
+
+
+            typename xt::xtensor<value_type, 1>::shape_type retshape;
+            retshape[0] = this->numberOfNodes();
+            xt::xtensor<value_type, 1> ret(retshape);
+
+
+            nifty::tools::forEachCoordinate(shape_, [&](const auto &coordP) {
+                const auto u = this->coordinateToNode(coordP);
+                const auto val = values[coordP];
+                ret[u] = val;
+            });
+
+            return ret;
+        }
 
         template<class D>
         auto edgeValues(
@@ -285,12 +327,15 @@ namespace graph{
                         const auto v = this->coordinateToNode(coordQ);
                         const auto e = this->findEdge(u,v);
 
-                        if(DIM == 2){
-                            const auto val = values(coordP[0],coordP[1], offsetIndex);
+                        array::StaticArray<int64_t, DIM + 1> valIndex;
+                        std::copy(std::begin(coordP), std::end(coordP), std::begin(valIndex));
+                        valIndex[DIM] = offsetIndex;
+                        const auto val = values[valIndex];
+
+                        if (not this->hasMaskedEdges_) {
+                            NIFTY_CHECK_OP(e,>=,0,"");
                             ret[e] = val;
-                        }
-                        else{
-                            const auto val = values(coordP[0],coordP[1],coordP[2], offsetIndex);
+                        } else if (e>=0) {
                             ret[e] = val;
                         }
                     }
@@ -299,6 +344,64 @@ namespace graph{
                 ++u;
             });
             
+            return ret;
+
+        }
+
+        // Maps Edge IDs to an image tensor (4D). If an edge does not exist, then value -1 is returned.
+        auto projectEdgesIDToPixels(
+        )const{
+            typename xt::xtensor<int64_t, DIM+1>::shape_type retshape;
+            for(auto d=0; d<DIM; ++d){
+                retshape[d] = shape_[d];
+            }
+            retshape[DIM] = offsets_.size();
+            xt::xtensor<int64_t, DIM+1> ret(retshape);
+
+            uint64_t u = 0;
+            nifty::tools::forEachCoordinate( shape_,[&](const auto & coordP){
+                auto offsetIndex = 0;
+                for(const auto & offset : offsets_){
+                    const auto coordQ = offset + coordP;
+                    int64_t e = -1;
+
+                    if(coordQ.allInsideShape(shape_)){
+                        const auto v = this->coordinateToNode(coordQ);
+                        e = this->findEdge(u,v);
+                        if (not this->hasMaskedEdges_) {
+                            NIFTY_CHECK_OP(e, >=, 0, "");
+                        }
+                    }
+
+                    array::StaticArray<int64_t, DIM + 1> retIndex;
+                    std::copy(std::begin(coordP), std::end(coordP), std::begin(retIndex));
+                    retIndex[DIM] = offsetIndex;
+
+                    ret[retIndex] = e;
+
+                    ++offsetIndex;
+                }
+                ++u;
+            });
+
+            return ret;
+
+        }
+
+        auto projectNodesIDToPixels(
+        )const{
+            typename xt::xtensor<uint64_t, DIM>::shape_type retshape;
+            for(auto d=0; d<DIM; ++d){
+                retshape[d] = shape_[d];
+            }
+            xt::xtensor<uint64_t, DIM> ret(retshape);
+
+
+            nifty::tools::forEachCoordinate( shape_,[&](const auto & coordP){
+                const auto u = this->coordinateToNode(coordP);
+                ret[coordP] = u;
+            });
+
             return ret;
 
         }
@@ -332,6 +435,7 @@ namespace graph{
         ShapeType shape_;
         StridesType strides_;
         OffsetVector offsets_;
+        bool hasMaskedEdges_;
 
     };
 }

--- a/src/python/module/nifty/graph/__init__.py
+++ b/src/python/module/nifty/graph/__init__.py
@@ -117,7 +117,13 @@ def undirectedGridGraph(shape, simpleNh=True):
 gridGraph = undirectedGridGraph
 
 
-def undirectedLongRangeGridGraph(shape, offsets):
+def undirectedLongRangeGridGraph(shape, offsets, edge_mask=None,
+                                 offsets_probabilities=None):
+    """
+    :param edge_mask: Boolean array (4D) indicating which edge connections should be introduced in the graph.
+    :param offsets_probabilities: Probability that a type of neighboring connection is introduced as edge in the graph.
+                Cannot be used at the same time with edge_mask
+    """
     offsets = numpy.require(offsets, dtype='int64')
     shape = list(shape)
     if len(shape) == 2:
@@ -127,7 +133,34 @@ def undirectedLongRangeGridGraph(shape, offsets):
     else:
         raise RuntimeError("wrong dimension: undirectedLongRangeGridGraph is only implemented for 2D and 3D")
 
-    return G(shape=shape, offsets=offsets)
+    if edge_mask is not None:
+        assert offsets_probabilities is None, "Edge mask and offsets probabilities cannot be used at the same time."
+        assert edge_mask.ndim == len(shape) + 1
+        assert edge_mask.dtype == numpy.dtype('bool')
+        assert edge_mask.shape[0] == offsets.shape[0]
+        edge_mask = numpy.rollaxis(edge_mask, axis=0, start=len(shape) + 1)
+
+        useEdgeMask = True
+    elif offsets_probabilities is not None:
+        offsets_probabilities = numpy.require(offsets_probabilities, dtype='float32')
+        assert offsets_probabilities.shape[0] == offsets.shape[0]
+        assert (offsets_probabilities.min() >= 0.0) and (offsets_probabilities.max() <= 1.0)
+
+        # Randomly sample some edges to add to the graph:
+        edge_mask = []
+        for off_prob in offsets_probabilities:
+            edge_mask.append(numpy.random.random(shape) <= off_prob)
+        edge_mask = numpy.stack(edge_mask, axis=-1)
+
+        useEdgeMask = True
+    else:
+        # Create an empty edge_mask (anyway it won't be used):
+        edge_mask = numpy.empty(tuple([1 for _ in range(len(shape) + 1)]), dtype='bool')
+        useEdgeMask = False
+
+
+    return G(shape=shape, offsets=offsets, edgeMask=edge_mask,
+             useEdgeMask=useEdgeMask)
 
 longRangeGridGraph = undirectedLongRangeGridGraph
 

--- a/src/python/test/graph/test_long_range_grid_graph.py
+++ b/src/python/test/graph/test_long_range_grid_graph.py
@@ -1,0 +1,46 @@
+from __future__ import print_function
+import unittest
+
+
+import numpy as np
+import nifty.graph as ngraph
+
+
+class TestUndirectedLongRangeGridGraph(unittest.TestCase):
+    shape_2d = 2 * (3,)
+    offsets_2d = [
+        [0, 2],
+        [1, 0],
+    ]
+    offsets_probabilities_2d = [0.3, 0.9]
+
+    def test_undirected_long_range_grid_graph_2d(self):
+        g = ngraph.undirectedLongRangeGridGraph(list(self.shape_2d),
+                                                self.offsets_2d)
+        self.assertTrue(g.numberOfNodes == 9)
+        self.assertTrue(g.numberOfEdges == 9)
+
+        # Call some extra methods:
+        edges_ID = g.projectEdgesIDToPixels()
+        nodes_ID = g.projectNodesIDToPixels()
+
+        edge_values = g.edgeValues(np.random.random(self.shape_2d + (len(self.offsets_2d),)).astype('float32'))
+        node_values = g.nodeValues(np.random.random(self.shape_2d).astype('float32'))
+
+
+    def test_edge_mask_2d(self):
+        np.random.seed(42)
+        edge_mask = np.random.random((len(self.offsets_2d),) + self.shape_2d) > 0.5
+        g1 = ngraph.undirectedLongRangeGridGraph(list(self.shape_2d),
+                                                 self.offsets_2d,
+                                                 offsets_probabilities=self.offsets_probabilities_2d,
+                                                 )
+        g2 = ngraph.undirectedLongRangeGridGraph(list(self.shape_2d),
+                                                 self.offsets_2d,
+                                                 edge_mask=edge_mask,
+                                                 )
+        # self.assertEqual(g2.numberOfEdges, 4)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I added the following functionalities:

- support for edge mask in undirectedLongRangeGridGraph (DIM+1 boolean tensor indicating which edges to add and which not)
- possibility to add edges with a certain probability (depending on the offset pattern)
- additional graph methods to project edgesID, nodesID, and node-features to pixels
